### PR TITLE
Skip URL prompt and set public access when auto-detected

### DIFF
--- a/sprite-setup.sh
+++ b/sprite-setup.sh
@@ -498,6 +498,7 @@ step_2_configuration() {
     ensure_shell_config_sourcing
 
     # Auto-detect sprite public URL if not already set
+    URL_AUTO_DETECTED=false
     if [ -z "$SPRITE_PUBLIC_URL" ]; then
         CURRENT_HOSTNAME=$(hostname)
 
@@ -515,6 +516,15 @@ step_2_configuration() {
                 if [ -n "$AUTO_DETECTED_URL" ]; then
                     SPRITE_PUBLIC_URL="$AUTO_DETECTED_URL"
                     echo "Auto-detected public URL: $SPRITE_PUBLIC_URL"
+                    URL_AUTO_DETECTED=true
+
+                    # Make the URL public
+                    echo "Setting URL to public access..."
+                    if sprite url update --auth public -s "$CURRENT_HOSTNAME" 2>/dev/null; then
+                        echo "URL access set to public"
+                    else
+                        echo "Warning: Could not set URL to public (may require permissions)"
+                    fi
                 else
                     echo "Could not parse public URL from API response"
                 fi
@@ -526,8 +536,11 @@ step_2_configuration() {
 
     # Prompt for URLs and repo (skip prompts in non-interactive mode)
     if [ "$NON_INTERACTIVE" != "true" ]; then
-        read -p "Sprite public URL (optional) [$SPRITE_PUBLIC_URL]: " input_url
-        SPRITE_PUBLIC_URL="${input_url:-$SPRITE_PUBLIC_URL}"
+        # Only prompt for URL if it wasn't auto-detected
+        if [ "$URL_AUTO_DETECTED" != "true" ]; then
+            read -p "Sprite public URL (optional) [$SPRITE_PUBLIC_URL]: " input_url
+            SPRITE_PUBLIC_URL="${input_url:-$SPRITE_PUBLIC_URL}"
+        fi
 
         read -p "sprite-mobile GitHub repo [$SPRITE_MOBILE_REPO]: " input_repo
         SPRITE_MOBILE_REPO="${input_repo:-$SPRITE_MOBILE_REPO}"


### PR DESCRIPTION
## Summary
When the sprite public URL is successfully auto-detected, the setup script now skips prompting the user for the URL and automatically sets it to public access.

## Changes
1. **Skip URL prompt when auto-detected**: Added a `URL_AUTO_DETECTED` flag that tracks whether auto-detection succeeded. If true, the interactive URL prompt is skipped.

2. **Automatically set public access**: After successful auto-detection, the script runs:
   ```bash
   sprite url update --auth public -s $HOSTNAME
   ```
   This ensures the sprite is publicly accessible without requiring manual configuration.

## Behavior
- **Auto-detection succeeds**: URL is detected, set to public, and user is NOT prompted
- **Auto-detection fails**: User is prompted for URL (existing behavior)
- **URL already set via env var**: No auto-detection attempt, uses provided value

## Benefits
- Fully automated setup when `SPRITE_API_TOKEN` is provided
- Ensures sprites are publicly accessible by default
- Reduces interactive prompts for better automation