### PR TITLE
Keep sprite awake by pre-warming sprite-mobile in tailnet-gate

### DIFF
--- a/sprite-setup.sh
+++ b/sprite-setup.sh
@@ -1352,7 +1352,20 @@ const html = \`<!DOCTYPE html>
 
 const server = Bun.serve({
   port: PORT,
-  fetch() {
+  async fetch() {
+    // Wake up sprite-mobile by making a backend request
+    // This ensures the sprite stays awake for the client's Tailscale connection
+    try {
+      await fetch("http://localhost:8081/api/config", {
+        signal: AbortSignal.timeout(2000)
+      }).catch(() => {
+        // Ignore errors - sprite-mobile might not be ready yet
+        // The client-side JavaScript will retry
+      });
+    } catch (e) {
+      // Ignore timeout or other errors
+    }
+
     return new Response(html, {
       headers: { "Content-Type": "text/html" },
     });


### PR DESCRIPTION
## Problem
With sprites now suspending properly, there's a timing issue with the tailnet-gate flow:

1. User accesses public URL → sprite wakes up
2. tailnet-gate serves HTML with JavaScript
3. Sprite suspends immediately after serving the response
4. JavaScript tries to connect to sprite-mobile via Tailscale → **fails because sprite is suspended**

The sprite won't wake up for the Tailscale connection because it only wakes for HTTP requests to the public URL (port 8080), not Tailscale connections.

## Solution
Modified tailnet-gate to make a backend request to sprite-mobile (`http://localhost:8081/api/config`) **before** serving the HTML response.

This ensures:
- sprite-mobile service wakes up when the gate is accessed
- Sprite stays awake while sprite-mobile is handling the request
- sprite-mobile is ready when the client's JavaScript connects via Tailscale

## Implementation Details
- Added async fetch handler in tailnet-gate
- Backend request has 2-second timeout
- Errors are silently ignored (sprite-mobile might not be ready yet)
- Client-side JavaScript retries provide additional resilience

## Testing
This should be tested by:
1. Accessing the public URL when sprite is suspended
2. Verifying the Tailscale connection succeeds without long delays