### PR TITLE
Open Tailscale URL in new window to keep stream alive

### DIFF
--- a/sprite-setup.sh
+++ b/sprite-setup.sh
@@ -1315,6 +1315,11 @@ const html = \`<!DOCTYPE html>
     <div class="emoji">👾 🚫</div>
     <h1>Unauthorized</h1>
   </div>
+  <div class="container" id="connected" style="display: none;">
+    <div class="emoji">👾 ✓</div>
+    <h1>Connected!</h1>
+    <p style="margin-top: 1rem; color: #aaa;">Keep this window open</p>
+  </div>
   <script>
     const tailscaleUrl = "\${TAILSCALE_URL}";
     const maxRetries = 10;
@@ -1327,7 +1332,10 @@ const html = \`<!DOCTYPE html>
           signal: AbortSignal.timeout(5000)
         });
         if (r.ok) {
-          window.location.href = tailscaleUrl;
+          // Open in new window to keep this connection alive
+          window.open(tailscaleUrl, '_blank');
+          document.getElementById('loading').style.display = 'none';
+          document.getElementById('connected').style.display = 'block';
         } else {
           throw new Error('not ok');
         }


### PR DESCRIPTION
## Problem
The previous implementation opened the Tailscale URL using `window.location.href = tailscaleUrl`, which navigated away from the public URL. This closed the streaming HTTP connection, causing the sprite to suspend and sprite-mobile to become unresponsive.

## Solution
Open the Tailscale URL in a **new window** using `window.open(tailscaleUrl, '_blank')` instead of redirecting. This keeps the original window open with the streaming connection alive.

## How It Works
1. User accesses public URL
2. Tailnet-gate starts streaming response (keeps connection open for 30 min)
3. JavaScript detects Tailscale is reachable
4. **Opens sprite-mobile in NEW window/tab** ← KEY CHANGE
5. Original window stays open with streaming connection
6. Stream keeps sprite awake while user works in new window

## User Experience
- Gate window shows "Connected! Keep this window open"
- New window/tab opens with sprite-mobile
- Users can use sprite-mobile normally
- Original gate window must stay open (can minimize it)

## Why This Works
Sprites stay awake while HTTP requests to the `http_port` are active. By keeping the original window open with the stream, we maintain an active HTTP connection to port 8080, preventing the sprite from suspending.

## Testing
Should verify:
1. Accessing public URL opens sprite-mobile in NEW window
2. Original window shows "Connected!" message
3. Sprite stays awake and responsive while working
4. Closing original window causes sprite to suspend after ~30s