### PR TITLE
Simplify gate: start keepalive before redirect

### DIFF
--- a/sprite-setup.sh
+++ b/sprite-setup.sh
@@ -1315,15 +1315,13 @@ const html = \`<!DOCTYPE html>
     <div class="emoji">👾 🚫</div>
     <h1>Unauthorized</h1>
   </div>
-  <div class="container" id="connected" style="display: none;">
-    <div class="emoji">👾 ✓</div>
-    <h1>Connected!</h1>
-    <p style="margin-top: 1rem; color: #aaa;">Keep this window open</p>
-  </div>
   <script>
     const tailscaleUrl = "\${TAILSCALE_URL}";
     const maxRetries = 10;
     const retryDelay = 2000;
+
+    // Start keepalive connection immediately to keep sprite awake during redirect
+    fetch('/keepalive').catch(() => {});
 
     async function tryConnect(attempt) {
       try {
@@ -1332,10 +1330,8 @@ const html = \`<!DOCTYPE html>
           signal: AbortSignal.timeout(5000)
         });
         if (r.ok) {
-          // Open in new window to keep this connection alive
-          window.open(tailscaleUrl, '_blank');
-          document.getElementById('loading').style.display = 'none';
-          document.getElementById('connected').style.display = 'block';
+          // Redirect to tailscale URL (sprite-mobile will take over keepalive)
+          window.location.href = tailscaleUrl;
         } else {
           throw new Error('not ok');
         }


### PR DESCRIPTION
## Problem  
The gate was opening Tailscale URL in a new window (`window.open()`), but the sprite would suspend between when the gate finished loading and when sprite-mobile could establish its own keepalive connection.

## Solution
Gate now:
1. Starts keepalive connection immediately on page load
2. Does a normal redirect (not new window) when Tailscale is reachable  
3. The ongoing keepalive keeps sprite awake during the redirect

## Changes
- Added `fetch('/keepalive')` immediately when gate page loads
- Changed back to `window.location.href` for redirect
- Removed "Connected! Keep this window open" message (no longer needed)

## Flow
1. User accesses public URL
2. Gate page loads, immediately starts `/keepalive` stream
3. Gate JavaScript checks if Tailscale URL is reachable
4. Gate redirects to Tailscale URL (normal redirect)
5. Gate's keepalive connection keeps sprite awake during redirect
6. sprite-mobile loads and starts its own keepalive
7. Both keepalives active briefly, ensuring no gap

## Benefits
- No suspension gap between gate and sprite-mobile
- Simpler UX (normal redirect, not popup)
- No need to keep extra windows open
- sprite-mobile's keepalive takes over once loaded

## Testing
Should verify:
1. Gate redirects successfully to Tailscale URL
2. No "Waiting for sprite..." delays
3. sprite-mobile loads and works immediately
4. Check console for two keepalive connections briefly overlapping