### PR TITLE
Revert to state before keepalive attempts (PR #3)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -306,51 +306,16 @@
     function startPublicKeepalive() {
       if (!spritePublicUrl || publicKeepaliveInterval) return;
 
-      console.log('[keepalive] Starting streaming connection to:', spritePublicUrl + '/keepalive');
-
-      // Start streaming keepalive connection
-      fetch(spritePublicUrl + '/keepalive', {
-        method: 'GET',
-        cache: 'no-store',
-      }).then(response => {
-        if (!response.ok) {
-          console.log('[keepalive] Failed to connect, status:', response.status);
-          // Retry after 5 seconds
-          setTimeout(startPublicKeepalive, 5000);
-          return;
-        }
-
-        console.log('[keepalive] Streaming connection established');
-        const reader = response.body.getReader();
-
-        // Read stream (keeps connection alive)
-        function read() {
-          reader.read().then(({ done }) => {
-            if (done) {
-              console.log('[keepalive] Stream closed, reconnecting...');
-              setTimeout(startPublicKeepalive, 1000);
-              return;
-            }
-            // Continue reading
-            read();
-          }).catch(err => {
-            console.log('[keepalive] Read error:', err, '- reconnecting...');
-            setTimeout(startPublicKeepalive, 1000);
-          });
-        }
-
-        read();
-      }).catch(err => {
-        console.log('[keepalive] Connection error:', err, '- retrying...');
-        setTimeout(startPublicKeepalive, 5000);
-      });
-
-      // Mark as started
-      publicKeepaliveInterval = true;
+      // Ping every 30 seconds
+      publicKeepaliveInterval = setInterval(pingPublicUrl, 30000);
     }
 
     function pingPublicUrl() {
-      // No longer used - keeping for backwards compatibility
+      if (!spritePublicUrl) return;
+
+      fetch(spritePublicUrl, { mode: 'no-cors', cache: 'no-store' })
+        .then(() => console.log('Public keepalive ping sent'))
+        .catch(() => console.log('Public keepalive ping failed'));
     }
 
     // Configure marked


### PR DESCRIPTION
## Summary
This reverts `sprite-setup.sh` and `public/app.js` back to their state at PR #3 (commit 890cae9), removing all the keepalive-related complexity from PRs #5-10.

## What's Removed
- `/keepalive` endpoint from tailnet-gate
- Streaming keepalive connection from sprite-mobile  
- `window.open()` redirect logic
- All background keepalive mechanisms

## What's Kept
- Service worker cache bump (separate commit, unrelated)
- All improvements from PRs #1-3:
  - Auto-detection of sprite public URL
  - Sprites CLI moved to first step
  - Skip URL prompt when auto-detected
  - Auto-set URL to public access

## Why
The keepalive approach was overly complex and causing issues:
- HTTP/2 protocol errors
- 502 bad gateway errors  
- window.open() behavior problems
- Sprite suspending despite keepalive attempts

## Next Steps
After this revert, we'll implement a simpler approach: serve sprite-mobile directly on port 8080 (the public http_port) with Tailscale-based access control. This means:
- Any HTTP request keeps sprite awake naturally
- No special keepalive connections needed
- No redirect complexity
- Much simpler architecture

This PR cleans the slate for that new approach.