### PR TITLE
Serve sprite-mobile directly on public port with Tailscale ACL

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -61,6 +61,18 @@ const server = Bun.serve({
   async fetch(req, server) {
     const url = new URL(req.url);
 
+    // Tailscale access control: only allow requests from tailnet
+    // Tailscale adds specific headers to requests from the tailnet
+    const isTailscaleRequest = req.headers.has("Tailscale-User") ||
+                                req.headers.has("Tailscale-Login");
+
+    if (!isTailscaleRequest) {
+      return new Response("Unauthorized - Access via Tailscale only", {
+        status: 403,
+        headers: { "Content-Type": "text/plain" }
+      });
+    }
+
     // Handle CORS preflight
     if (req.method === "OPTIONS") {
       return new Response(null, { headers: corsHeaders });

--- a/start-service.sh
+++ b/start-service.sh
@@ -9,6 +9,9 @@ if [ -f "$HOME/.sprite-config" ]; then
     set +a  # Stop exporting
 fi
 
+# Set PORT for sprite-mobile (public http_port)
+export PORT=8080
+
 # Ensure .env file has secure permissions
 if [ -f "$HOME/.sprite-mobile/.env" ]; then
     chmod 600 "$HOME/.sprite-mobile/.env"


### PR DESCRIPTION
## Summary
Completely redesigned architecture: sprite-mobile now serves directly on port 8080 (the public `http_port`) and uses Tailscale headers for access control. This eliminates the need for the tailnet-gate service and all keepalive complexity.

## Key Changes

### 1. sprite-mobile serves on port 8080
- Changed from port 8081 to port 8080
- Configured as `http_port` in service definition
- Any HTTP request keeps sprite awake automatically

### 2. Tailscale-based access control
Added middleware in `server.ts` that checks for Tailscale headers:
```typescript
const isTailscaleRequest = req.headers.has("Tailscale-User") ||
                            req.headers.has("Tailscale-Login");

if (!isTailscaleRequest) {
  return new Response("Unauthorized - Access via Tailscale only", {
    status: 403
  });
}
```

When requests come through Tailscale, these headers are automatically added. Public internet requests don't have them.

### 3. Removed tailnet-gate service
- Step 10 now just cleans up old tailnet-gate if it exists
- No more redirect complexity
- No more separate wake-up service

## How It Works

**Before:**
1. Public URL → tailnet-gate on port 8080
2. Gate checks if Tailscale reachable
3. Gate redirects to Tailscale URL
4. sprite-mobile on port 8081 (separate)
5. Complicated keepalive mechanisms needed

**After:**
1. Public URL → sprite-mobile on port 8080
2. sprite-mobile checks Tailscale headers
3. Rejects if not from Tailscale (403)
4. Serves normally if from Tailscale
5. Any HTTP activity keeps sprite awake automatically

## Benefits

1. **Natural keepalive**: Any HTTP request to port 8080 keeps sprite awake
2. **Simpler architecture**: One service instead of two
3. **No redirects**: Users go straight to sprite-mobile
4. **Access control**: Tailscale headers provide security
5. **No special code**: No keepalive connections, streaming, etc.

## Security

Tailscale automatically adds headers to requests that come through the tailnet:
- `Tailscale-User`: The user's tailnet identity
- `Tailscale-Login`: The user's login name

Public internet requests will never have these headers, so they get rejected with 403.

## Migration

Existing sprites will need to:
1. Run step 8 to update sprite-mobile service
2. Run step 10 to clean up old tailnet-gate
3. Restart sprite-mobile to pick up changes

The old tailnet-gate service will be automatically removed.

## Testing

Should verify:
1. Public URL access gets 403 (unauthorized)
2. Tailscale URL access works normally
3. sprite-mobile loads and functions correctly
4. Sprite stays awake during use
5. No tailnet-gate service running