### PR TITLE
Add console debugging for hash syncing

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -7,19 +7,31 @@
 
     // Sync hash with parent window (if in iframe)
     if (window.parent !== window) {
+      console.log('[iframe] Detected running in iframe, enabling hash sync');
+      console.log('[iframe] Initial hash:', window.location.hash);
+
       // Notify parent of hash changes
       window.addEventListener('hashchange', () => {
+        console.log('[iframe] Hash changed to:', window.location.hash);
+        console.log('[iframe] Sending postMessage to parent');
         window.parent.postMessage({ type: 'hashchange', hash: window.location.hash }, '*');
       });
 
       // Listen for hash changes from parent
       window.addEventListener('message', (event) => {
+        console.log('[iframe] Received message from parent:', event.data);
         if (event.data && event.data.type === 'hashchange' && event.data.hash !== undefined) {
+          console.log('[iframe] Parent sent new hash:', event.data.hash);
           if (window.location.hash !== event.data.hash) {
+            console.log('[iframe] Updating hash to:', event.data.hash);
             window.location.hash = event.data.hash;
+          } else {
+            console.log('[iframe] Hash already matches, no update needed');
           }
         }
       });
+    } else {
+      console.log('[iframe] NOT in iframe, hash sync disabled');
     }
 
     // Elements

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Sprite Code PWA
 // Caches shell for offline-first loading and stores public URL for sprite wake-up
 
-const CACHE_VERSION = 'v22';
+const CACHE_VERSION = 'v23';
 const SHELL_CACHE = `shell-${CACHE_VERSION}`;
 const CONFIG_CACHE = `config-${CACHE_VERSION}`;
 

--- a/sprite-setup.sh
+++ b/sprite-setup.sh
@@ -1287,19 +1287,28 @@ const html = \`<!DOCTYPE html>
     const tailscaleUrl = "\${TAILSCALE_URL}";
     const hash = window.location.hash;
     const iframe = document.getElementById('app-frame');
+    console.log('[gate] Initial hash:', hash);
+    console.log('[gate] Setting iframe src to:', tailscaleUrl + hash);
     iframe.src = tailscaleUrl + hash;
 
     // Update iframe when outer hash changes
     window.addEventListener('hashchange', () => {
       const newHash = window.location.hash;
+      console.log('[gate] Outer hash changed to:', newHash);
+      console.log('[gate] Sending postMessage to iframe');
       iframe.contentWindow.postMessage({ type: 'hashchange', hash: newHash }, '*');
     });
 
     // Update outer URL when iframe hash changes
     window.addEventListener('message', (event) => {
+      console.log('[gate] Received message:', event.data, 'from origin:', event.origin);
       if (event.data && event.data.type === 'hashchange' && event.data.hash !== undefined) {
+        console.log('[gate] iframe sent new hash:', event.data.hash);
         if (window.location.hash !== event.data.hash) {
+          console.log('[gate] Updating outer URL hash to:', event.data.hash);
           window.location.hash = event.data.hash;
+        } else {
+          console.log('[gate] Hash already matches, no update needed');
         }
       }
     });


### PR DESCRIPTION
## Summary
Adds detailed console logging to diagnose why hash syncing from iframe → parent isn't working.

## Debugging Added

### iframe (app.js)
- Logs whether running in iframe or not
- Logs initial hash on load
- Logs every hash change and postMessage sent to parent
- Logs messages received from parent
- Logs hash updates from parent

### Parent (sprite-setup.sh tailnet-gate)
- Logs initial hash on load
- Logs iframe src being set
- Logs outer hash changes and postMessages to iframe
- Logs all messages received from any source (including origin)
- Logs hash updates from iframe

## Cache Bump
- Bumped cache to v23 to force service worker update

## How to Test
1. Update sprite: `./sprite-setup.sh 10 8`
2. Open public URL in browser
3. Open DevTools console
4. Create a new session
5. Look for `[gate]` and `[iframe]` prefixed messages
6. Check if iframe is detected, if messages are being sent/received

This will help us see exactly where the communication is breaking down.