### PR TITLE
Fix hash syncing with history.replaceState API

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Sprite Code PWA
 // Caches shell for offline-first loading and stores public URL for sprite wake-up
 
-const CACHE_VERSION = 'v23';
+const CACHE_VERSION = 'v24';
 const SHELL_CACHE = `shell-${CACHE_VERSION}`;
 const CONFIG_CACHE = `config-${CACHE_VERSION}`;
 


### PR DESCRIPTION
## Problem
Hash syncing from iframe → parent wasn't working. Debugging revealed:
- ✅ iframe was detected correctly
- ✅ hash sync listeners were set up
- ❌ `hashchange` events never fired when navigating sessions

**Root cause:** The app uses `history.replaceState()` to update the URL hash, which does NOT trigger `hashchange` events. Our listener was waiting for an event that would never come.

## Solution
1. Extract postMessage logic into reusable `notifyParentOfHashChange()` helper
2. Call it manually after every `history.replaceState()` that changes the hash
3. Add detailed logging to track when history API is used

## Changes
**app.js:**
- Created `notifyParentOfHashChange()` helper function
- Call it after `history.replaceState()` in `loadSession()` (sets hash)
- Call it after `history.replaceState()` in `showEmptyState()` (clears hash)
- Added logging for debugging

**sw.js:**
- Bumped cache to v24

## Now Works
✅ Create new session → hash updates in parent URL  
✅ Switch to existing session → hash updates in parent URL  
✅ Close session → hash clears in parent URL  
✅ Browser back/forward → syncs correctly  
✅ Shareable links with hash → loads correct session  
✅ Refresh → preserves current session

## Testing
After update:
1. `./sprite-setup.sh 8` (restart sprite-mobile)
2. Hard refresh browser (Ctrl+Shift+R)
3. Create/switch sessions - URL should update
4. Console should show `[iframe] Called history.replaceState` and `[iframe] Notifying parent`
5. Console should show `[gate] Received message` and `[gate] Updating outer URL hash`