### PR TITLE
Remove hash syncing debug logging

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -10,37 +10,23 @@
     let notifyParentOfHashChange;
 
     if (isInIframe) {
-      console.log('[iframe] Detected running in iframe, enabling hash sync');
-      console.log('[iframe] Initial hash:', window.location.hash);
-
       // Helper to notify parent of hash changes
       notifyParentOfHashChange = () => {
-        const hash = window.location.hash;
-        console.log('[iframe] Notifying parent of hash:', hash);
-        window.parent.postMessage({ type: 'hashchange', hash: hash }, '*');
+        window.parent.postMessage({ type: 'hashchange', hash: window.location.hash }, '*');
       };
 
       // Notify parent when hash changes via hashchange event
-      window.addEventListener('hashchange', () => {
-        console.log('[iframe] hashchange event fired, hash:', window.location.hash);
-        notifyParentOfHashChange();
-      });
+      window.addEventListener('hashchange', notifyParentOfHashChange);
 
       // Listen for hash changes from parent
       window.addEventListener('message', (event) => {
-        console.log('[iframe] Received message from parent:', event.data);
         if (event.data && event.data.type === 'hashchange' && event.data.hash !== undefined) {
-          console.log('[iframe] Parent sent new hash:', event.data.hash);
           if (window.location.hash !== event.data.hash) {
-            console.log('[iframe] Updating hash to:', event.data.hash);
             window.location.hash = event.data.hash;
-          } else {
-            console.log('[iframe] Hash already matches, no update needed');
           }
         }
       });
     } else {
-      console.log('[iframe] NOT in iframe, hash sync disabled');
       // No-op when not in iframe
       notifyParentOfHashChange = () => {};
     }
@@ -500,7 +486,6 @@
       // Update URL hash to persist session across refreshes
       history.replaceState(null, '', `#session=${session.id}`);
       // Manually notify parent since history.replaceState doesn't trigger hashchange
-      console.log('[iframe] Called history.replaceState with session:', session.id);
       notifyParentOfHashChange();
     }
 
@@ -517,7 +502,6 @@
       // Clear URL hash when no session selected
       history.replaceState(null, '', location.pathname);
       // Manually notify parent since history.replaceState doesn't trigger hashchange
-      console.log('[iframe] Called history.replaceState to clear hash');
       notifyParentOfHashChange();
     }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Sprite Code PWA
 // Caches shell for offline-first loading and stores public URL for sprite wake-up
 
-const CACHE_VERSION = 'v24';
+const CACHE_VERSION = 'v25';
 const SHELL_CACHE = `shell-${CACHE_VERSION}`;
 const CONFIG_CACHE = `config-${CACHE_VERSION}`;
 

--- a/sprite-setup.sh
+++ b/sprite-setup.sh
@@ -1287,28 +1287,19 @@ const html = \`<!DOCTYPE html>
     const tailscaleUrl = "\${TAILSCALE_URL}";
     const hash = window.location.hash;
     const iframe = document.getElementById('app-frame');
-    console.log('[gate] Initial hash:', hash);
-    console.log('[gate] Setting iframe src to:', tailscaleUrl + hash);
     iframe.src = tailscaleUrl + hash;
 
     // Update iframe when outer hash changes
     window.addEventListener('hashchange', () => {
       const newHash = window.location.hash;
-      console.log('[gate] Outer hash changed to:', newHash);
-      console.log('[gate] Sending postMessage to iframe');
       iframe.contentWindow.postMessage({ type: 'hashchange', hash: newHash }, '*');
     });
 
     // Update outer URL when iframe hash changes
     window.addEventListener('message', (event) => {
-      console.log('[gate] Received message:', event.data, 'from origin:', event.origin);
       if (event.data && event.data.type === 'hashchange' && event.data.hash !== undefined) {
-        console.log('[gate] iframe sent new hash:', event.data.hash);
         if (window.location.hash !== event.data.hash) {
-          console.log('[gate] Updating outer URL hash to:', event.data.hash);
           window.location.hash = event.data.hash;
-        } else {
-          console.log('[gate] Hash already matches, no update needed');
         }
       }
     });


### PR DESCRIPTION
Hash syncing is working correctly now, so clean up all the debug console.log statements.

## Removed
- All `[iframe]` prefixed logs from app.js
- All `[gate]` prefixed logs from sprite-setup.sh

## Kept
- All functionality intact
- Comments explaining the code

## Changes
- app.js: Removed 10+ console.log statements
- sprite-setup.sh: Removed 7 console.log statements  
- sw.js: Bumped cache to v25

Much cleaner console output while preserving all hash syncing functionality.