### PR TITLE
Clear hash when session not found and show unauthorized screen

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Sprite Code PWA
 // Caches shell for offline-first loading and stores public URL for sprite wake-up
 
-const CACHE_VERSION = 'v25';
+const CACHE_VERSION = 'v26';
 const SHELL_CACHE = `shell-${CACHE_VERSION}`;
 const CONFIG_CACHE = `config-${CACHE_VERSION}`;
 


### PR DESCRIPTION
## Summary
Two improvements to hash handling and unauthorized access detection.

## 1. Clear Hash When Session Not Found

**Problem:** When a user visits a URL with a session hash (e.g., `#session=abc123`) but that session doesn't exist (deleted, wrong sprite, etc.), the hash stays in the URL even though no session is loaded.

**Solution:** 
- Detect when session from hash doesn't exist in sessions list
- Clear hash from URL using `history.replaceState()`
- Notify parent frame to sync the cleared hash

**Code:**
```javascript
if (session) {
  selectSession(session);
} else if (hashSessionId) {
  // Session from hash not found, clear the hash
  history.replaceState(null, '', location.pathname);
  notifyParentOfHashChange();
}
```

## 2. Show Unauthorized Screen

**Problem:** When a user visits the public URL but isn't on the Tailscale network, the iframe just fails to load silently with a blank screen.

**Solution:**
- iframe sends a 'ready' message when it loads successfully
- Parent sets a 10-second timeout waiting for the message
- If timeout expires without message, assume unauthorized
- Hide iframe and show unauthorized screen with sprite emoji

**UI:**
```
👾 🚫

Unauthorized
You must be on the Tailscale network to access this sprite
```

**How it works:**
1. app.js sends `postMessage({ type: 'ready' })` when loaded
2. tailnet-gate waits for any message from iframe
3. Any message = iframe loaded = clear timeout
4. No message after 10s = not authorized = show error screen

## 3. Page Title Uses Sprite Hostname

**Change:** Browser tab now shows sprite hostname (e.g., "town-happiness") instead of generic "Sprite Mobile".

## Testing

**Hash clearing:**
1. Visit URL with non-existent session: `https://sprite.sprites.app#session=fake-id`
2. Hash should clear from URL automatically

**Unauthorized screen:**
1. Visit public URL from device NOT on Tailscale
2. Should see unauthorized screen after ~10 seconds
3. Visit from device ON Tailscale
4. Should load normally, no unauthorized screen

**Title:**
1. Check browser tab
2. Should show sprite hostname

## Changes
- app.js: Clear hash when session not found, send ready message
- sprite-setup.sh: Detect iframe load failure, show unauthorized UI, use hostname in title
- sw.js: Bump cache to v26