### PR TITLE
Reduce unauthorized timeout from 10s to 4s

### DIFF
--- a/sprite-setup.sh
+++ b/sprite-setup.sh
@@ -1334,7 +1334,7 @@ const html = \`<!DOCTYPE html>
         iframe.style.display = 'none';
         unauthorized.classList.add('visible');
       }
-    }, 10000); // 10 second timeout
+    }, 4000); // 4 second timeout
 
     // Update iframe when outer hash changes
     window.addEventListener('hashchange', () => {


### PR DESCRIPTION
Faster feedback when user is not on Tailscale network.

Changed timeout from 10 seconds to 4 seconds before showing unauthorized screen.