### PR TITLE
Navigate parent window when switching sprites in iframe

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1508,7 +1508,17 @@
 
       if (switchingSubtext) switchingSubtext.textContent = 'Navigating...';
       await new Promise(r => setTimeout(r, 300));
-      window.location.href = tailscaleUrl;
+
+      // Navigate based on iframe context
+      if (isInIframe && publicUrl) {
+        // In iframe: navigate parent window to public URL (updates address bar)
+        console.log('[iframe] Navigating parent to public URL:', publicUrl);
+        window.parent.location.href = publicUrl;
+      } else {
+        // Not in iframe: navigate directly to Tailscale URL
+        console.log('Navigating to Tailscale URL:', tailscaleUrl);
+        window.location.href = tailscaleUrl;
+      }
     }
 
     // Check network status on startup

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Sprite Code PWA
 // Caches shell for offline-first loading and stores public URL for sprite wake-up
 
-const CACHE_VERSION = 'v26';
+const CACHE_VERSION = 'v27';
 const SHELL_CACHE = `shell-${CACHE_VERSION}`;
 const CONFIG_CACHE = `config-${CACHE_VERSION}`;
 


### PR DESCRIPTION
When sprite-mobile is embedded in an iframe (via the tailnet gate), clicking on a sprite in the network modal should navigate the parent window to that sprite's public URL, updating the address bar.

## Previously
- Clicking a network sprite navigated only the iframe to the Tailscale URL
- Address bar stayed on the original sprite's public URL
- User couldn't bookmark or share the new sprite's URL

## Now
- Detects iframe context using `isInIframe` variable
- Navigates parent window to target sprite's public URL
- Address bar updates to show the new sprite's URL
- Fallback to Tailscale URL if no public URL available
- Non-iframe behavior unchanged (direct Tailscale navigation)

## Changes
- Modified `navigateToNetworkSprite()` to check iframe context
- When in iframe with public URL: navigate parent to public URL
- When not in iframe: navigate directly to Tailscale URL (existing behavior)
- Bump cache to v27

## Testing
Tested by opening sprite-mobile via public URL (iframe context) and clicking network sprites to verify address bar updates.