### PR TITLE
Add automated sprite creation and non-interactive setup

### DIFF
--- a/CREATE_SPRITE.md
+++ b/CREATE_SPRITE.md
@@ -1,0 +1,215 @@
+# Creating New Sprites
+
+This guide explains how to create and configure new sprites with sprite-mobile from an existing sprite.
+
+## Quick Start
+
+From any sprite with sprite-mobile installed:
+
+```bash
+~/.sprite-mobile/create-sprite.sh <sprite-name>
+```
+
+This single command will:
+1. Create a new sprite with the given name
+2. Make its URL public
+3. Transfer your `.sprite-config` to the new sprite
+4. Run the full setup script non-interactively
+5. Verify all services are running
+
+## Example
+
+```bash
+~/.sprite-mobile/create-sprite.sh my-test-sprite
+```
+
+## What Gets Transferred
+
+The script transfers your `~/.sprite-config` which includes:
+- Git configuration (user.name, user.email)
+- Claude CLI OAuth token
+- GitHub CLI token
+- Fly.io API token
+- Sprite API token
+- Tailscale auth key
+- Sprite Network credentials
+
+The following are **unique per sprite** and NOT transferred:
+- Hostname (set via sprite name parameter)
+- Public URL (auto-generated from sprite name)
+- Tailscale Serve URL (generated during setup)
+
+## How It Works
+
+### 1. Auto-Detection
+
+The setup script now automatically detects `~/.sprite-config` and enables non-interactive mode:
+
+```bash
+# Old way (manual)
+set -a && source ~/.sprite-config && set +a && export NON_INTERACTIVE=true && ~/sprite-setup.sh all
+
+# New way (automatic)
+~/sprite-setup.sh all
+```
+
+If `~/.sprite-config` exists, the script will:
+- Source it automatically
+- Enable non-interactive mode
+- Use all credentials without prompting
+
+### 2. Create Script Flow
+
+The `create-sprite.sh` script follows this flow:
+
+```
+1. Check prerequisites
+   - Verify ~/.sprite-config exists
+   - Determine current organization
+
+2. Create sprite
+   - Run: sprite create -o <org> <name>
+   - Skip if sprite already exists
+
+3. Make URL public
+   - Run: sprite url update --auth public
+   - Extract and display public URL
+
+4. Transfer config
+   - cat ~/.sprite-config | sprite exec -- cat > ~/.sprite-config
+   - Clean up any control characters
+
+5. Download setup script
+   - curl sprite-setup.sh to new sprite
+
+6. Run setup
+   - sprite exec -- ./sprite-setup.sh all
+   - Auto-detects ~/.sprite-config
+   - Runs completely non-interactively
+
+7. Verify
+   - List running services
+   - Display access URLs
+```
+
+## Requirements
+
+### On Source Sprite
+- sprite-mobile installed at `~/.sprite-mobile/`
+- Valid `~/.sprite-config` file
+- Sprite CLI authenticated
+- Tailscale reusable auth key in config
+
+### For Non-Interactive Setup
+
+The following must be in your `~/.sprite-config`:
+
+```bash
+# Git configuration
+GIT_USER_NAME=your-name
+GIT_USER_EMAIL=your@email.com
+
+# Authentication tokens
+GH_TOKEN=ghp_xxx
+CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-xxx
+TAILSCALE_AUTH_KEY=tskey-auth-xxx  # Must be reusable!
+FLY_API_TOKEN=fm2_xxx
+SPRITE_API_TOKEN=org/id/token/value
+
+# Sprite Network (optional)
+SPRITE_NETWORK_S3_BUCKET=sprites-network-org
+SPRITE_NETWORK_S3_ACCESS_KEY=tid_xxx
+SPRITE_NETWORK_S3_SECRET_KEY=tsec_xxx
+SPRITE_NETWORK_S3_ENDPOINT=https://fly.storage.tigris.dev
+SPRITE_NETWORK_ORG=your-org
+
+# Repository
+SPRITE_MOBILE_REPO=https://github.com/user/sprite-mobile
+```
+
+**Important:** The Tailscale auth key MUST be reusable. Create one at:
+https://login.tailscale.com/admin/settings/keys
+
+## Troubleshooting
+
+### "Authentication failed"
+
+Ensure your Sprite CLI is authenticated:
+```bash
+sprite org list
+```
+
+If not authenticated:
+```bash
+sprite login
+# or
+sprite auth setup --token "org/id/token/value"
+```
+
+### "No ~/.sprite-config found"
+
+Create it from scratch:
+```bash
+~/.sprite-mobile/sprite-setup.sh --export > ~/.sprite-config
+```
+
+Or copy from another sprite:
+```bash
+scp other-sprite:~/.sprite-config ~/.sprite-config
+```
+
+### Setup hangs or prompts for input
+
+This means `~/.sprite-config` is missing required credentials. Check:
+```bash
+grep -E 'CLAUDE_CODE_OAUTH_TOKEN|GH_TOKEN|TAILSCALE_AUTH_KEY|FLY_API_TOKEN' ~/.sprite-config
+```
+
+Add any missing tokens to the file.
+
+### "Tailscale auth key is not reusable"
+
+The auth key in your config must be a reusable key. Create a new one:
+1. Visit https://login.tailscale.com/admin/settings/keys
+2. Click "Generate auth key"
+3. Check "Reusable"
+4. Copy the key
+5. Update `~/.sprite-config`: `TAILSCALE_AUTH_KEY=tskey-auth-xxx`
+
+## Manual Alternative
+
+If you prefer manual control:
+
+```bash
+# 1. Create sprite
+sprite create my-sprite
+
+# 2. Make URL public
+sprite url update --auth public -s my-sprite
+
+# 3. Transfer config
+cat ~/.sprite-config | sprite -s my-sprite exec -- cat > ~/.sprite-config
+
+# 4. Download and run setup
+sprite -s my-sprite exec -- bash -c "
+  curl -fsSL https://gist.githubusercontent.com/clouvet/901dabc09e62648fa394af65ad004d04/raw/sprite-setup.sh -o ~/sprite-setup.sh
+  chmod +x ~/sprite-setup.sh
+  ~/sprite-setup.sh all
+"
+```
+
+## Testing
+
+The `create-sprite.sh` script is safe to test repeatedly:
+- Creating an existing sprite just skips creation
+- Setup steps are idempotent (safe to re-run)
+- Services are restarted if already running
+
+Test by creating a few sprites:
+```bash
+~/.sprite-mobile/create-sprite.sh test-1
+~/.sprite-mobile/create-sprite.sh test-2
+~/.sprite-mobile/create-sprite.sh test-3
+```
+
+All sprites will appear in your sprite network automatically!

--- a/create-sprite.sh
+++ b/create-sprite.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+# Helper script to create and configure a new sprite with sprite-mobile
+# Usage: ./create-sprite.sh <sprite-name>
+
+# Handle Ctrl+C gracefully
+trap 'echo ""; echo "Aborted."; exit 130' INT
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <sprite-name>"
+    echo ""
+    echo "Example: $0 my-new-sprite"
+    echo ""
+    echo "This script will:"
+    echo "  1. Create a new sprite with the given name"
+    echo "  2. Make its URL public"
+    echo "  3. Transfer .sprite-config from current sprite"
+    echo "  4. Run sprite-setup.sh non-interactively"
+    exit 1
+fi
+
+SPRITE_NAME="$1"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "============================================"
+echo "Creating and Configuring Sprite"
+echo "============================================"
+echo ""
+echo "Target sprite: $SPRITE_NAME"
+echo ""
+
+# Check if .sprite-config exists
+if [ ! -f "$HOME/.sprite-config" ]; then
+    echo "Error: ~/.sprite-config not found"
+    echo "This file is required to transfer configuration to the new sprite"
+    exit 1
+fi
+
+# Determine the organization
+ORG=$(sprite org list 2>/dev/null | grep "Currently selected org:" | awk '{print $NF}' || echo "")
+if [ -z "$ORG" ]; then
+    echo "Error: Could not determine current sprite organization"
+    echo "Run 'sprite org list' to check your authentication"
+    exit 1
+fi
+
+echo "Using organization: $ORG"
+echo ""
+
+# Step 1: Create sprite (skip if already exists)
+echo "Step 1: Creating sprite..."
+if sprite list -o "$ORG" 2>/dev/null | grep -q "^${SPRITE_NAME}$"; then
+    echo "  Sprite '$SPRITE_NAME' already exists, skipping creation"
+else
+    if sprite create -o "$ORG" --skip-console "$SPRITE_NAME" 2>&1 | grep -q "Error"; then
+        echo "  Warning: Sprite creation failed, but it may already exist"
+    else
+        echo "  Created sprite: $SPRITE_NAME"
+    fi
+fi
+echo ""
+
+# Step 2: Make URL public
+echo "Step 2: Making URL public..."
+sprite url update --auth public -s "$SPRITE_NAME" -o "$ORG"
+PUBLIC_URL=$(sprite api /v1/sprites/"$SPRITE_NAME" 2>/dev/null | grep -o '"url"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*: *"\([^"]*\)".*/\1/' | head -1)
+if [ -n "$PUBLIC_URL" ]; then
+    echo "  Public URL: $PUBLIC_URL"
+fi
+echo ""
+
+# Step 3: Transfer .sprite-config
+echo "Step 3: Transferring configuration..."
+# Create a temporary file with the config (without trailing control chars)
+TEMP_CONFIG=$(mktemp)
+head -n -1 "$HOME/.sprite-config" 2>/dev/null > "$TEMP_CONFIG" || cat "$HOME/.sprite-config" > "$TEMP_CONFIG"
+# Encode as base64 to avoid shell escaping issues
+CONFIG_B64=$(base64 -w0 "$TEMP_CONFIG" 2>/dev/null || base64 "$TEMP_CONFIG" | tr -d '\n')
+rm "$TEMP_CONFIG"
+# Transfer and decode on target
+sprite -s "$SPRITE_NAME" -o "$ORG" exec -- bash -c "echo '$CONFIG_B64' | base64 -d > ~/.sprite-config && chmod 600 ~/.sprite-config"
+echo "  Transferred ~/.sprite-config"
+echo ""
+
+# Step 4: Download setup script
+echo "Step 4: Downloading setup script..."
+sprite -s "$SPRITE_NAME" -o "$ORG" exec -- bash -c "curl -fsSL https://gist.githubusercontent.com/clouvet/901dabc09e62648fa394af65ad004d04/raw/sprite-setup.sh -o ~/sprite-setup.sh && chmod +x ~/sprite-setup.sh"
+echo "  Downloaded sprite-setup.sh"
+echo ""
+
+# Step 5: Run setup script
+echo "Step 5: Running setup script (this may take 3-5 minutes)..."
+echo ""
+sprite -s "$SPRITE_NAME" -o "$ORG" exec -- bash -c "set -a && source ~/.sprite-config && set +a && export NON_INTERACTIVE=true && cd ~ && ./sprite-setup.sh all"
+echo ""
+
+# Step 6: Verify services
+echo "============================================"
+echo "Setup Complete!"
+echo "============================================"
+echo ""
+echo "Sprite: $SPRITE_NAME"
+if [ -n "$PUBLIC_URL" ]; then
+    echo "Public URL: $PUBLIC_URL"
+fi
+echo ""
+echo "Verifying services..."
+sprite -s "$SPRITE_NAME" -o "$ORG" exec -- sprite-env services list | grep -o '"name":"[^"]*"' | sed 's/"name":"/  - /' | sed 's/"$//'
+echo ""
+echo "To access the sprite:"
+if [ -n "$PUBLIC_URL" ]; then
+    echo "  Public: $PUBLIC_URL"
+fi
+echo "  SSH: sprite -s $SPRITE_NAME shell"
+echo ""

--- a/sprite-setup.sh
+++ b/sprite-setup.sh
@@ -13,6 +13,18 @@ trap 'echo ""; echo "Aborted."; exit 130' INT
 NON_INTERACTIVE="${NON_INTERACTIVE:-false}"
 CONFIG_FILE=""
 
+# Auto-detect .sprite-config and enable non-interactive mode
+SPRITE_CONFIG_FILE="$HOME/.sprite-config"
+if [ -f "$SPRITE_CONFIG_FILE" ] && [ "$NON_INTERACTIVE" != "true" ] && [ -z "$CONFIG_FILE" ]; then
+    echo "Detected ~/.sprite-config, enabling non-interactive mode..."
+    set -a  # Export all variables
+    source "$SPRITE_CONFIG_FILE"
+    set +a  # Stop exporting
+    NON_INTERACTIVE="true"
+    echo "Loaded configuration from ~/.sprite-config"
+    echo ""
+fi
+
 # Sprite API helper
 sprite_api() { sprite-env curl "$@"; }
 


### PR DESCRIPTION
Enables one sprite to create and fully configure another sprite with a single command, making sprite fleet management effortless.

## New Features

### 1. `create-sprite.sh` - Automated Sprite Creation

Single command to create and configure a new sprite:
```bash
~/.sprite-mobile/create-sprite.sh my-new-sprite
```

This script automatically:
- Creates the sprite
- Makes its URL public
- Transfers `~/.sprite-config`
- Downloads and runs `sprite-setup.sh`
- Verifies all services are running

**Result:** Fully configured sprite with sprite-mobile in 3-5 minutes.

### 2. sprite-setup.sh Auto-Detection

The setup script now automatically detects `~/.sprite-config` and enables non-interactive mode:

**Before:**
```bash
set -a && source ~/.sprite-config && set +a && export NON_INTERACTIVE=true && ~/sprite-setup.sh all
```

**After:**
```bash
~/sprite-setup.sh all
```

When `~/.sprite-config` exists, the script:
- Sources it automatically
- Enables non-interactive mode
- Uses all credentials without prompting

### 3. CREATE_SPRITE.md Documentation

Comprehensive guide covering:
- Quick start examples
- Requirements and prerequisites
- How auto-detection works
- Troubleshooting common issues
- Testing recommendations

## Implementation Details

### Auto-Detection Logic

Added to `sprite-setup.sh`:
```bash
# Auto-detect .sprite-config and enable non-interactive mode
SPRITE_CONFIG_FILE="$HOME/.sprite-config"
if [ -f "$SPRITE_CONFIG_FILE" ] && [ "$NON_INTERACTIVE" \!= "true" ] && [ -z "$CONFIG_FILE" ]; then
    echo "Detected ~/.sprite-config, enabling non-interactive mode..."
    set -a  # Export all variables
    source "$SPRITE_CONFIG_FILE"
    set +a  # Stop exporting
    NON_INTERACTIVE="true"
fi
```

### Config Transfer (Base64)

Uses base64 encoding to avoid shell escaping issues:
```bash
CONFIG_B64=$(base64 -w0 "$TEMP_CONFIG")
sprite exec -- bash -c "echo '$CONFIG_B64' | base64 -d > ~/.sprite-config"
```

## Testing

Successfully created and configured three test sprites:
- `test-sprite-1` ✅
- `test-sprite-2` ✅
- `test-sprite-3` ✅

All sprites:
- Completed setup in 3-5 minutes
- All services running (sprite-mobile, tailnet-gate, tailscaled)
- Registered in sprite network
- Accessible via public URL

## Requirements

For fully automated setup, `~/.sprite-config` must include:
- `GIT_USER_NAME` and `GIT_USER_EMAIL`
- `CLAUDE_CODE_OAUTH_TOKEN`
- `GH_TOKEN`
- `TAILSCALE_AUTH_KEY` (must be reusable\!)
- `FLY_API_TOKEN`
- `SPRITE_API_TOKEN`
- `SPRITE_NETWORK_*` variables (optional)

## Use Cases

1. **Quick sprite creation:**
   ```bash
   ~/.sprite-mobile/create-sprite.sh dev-sprite
   ```

2. **Sprite fleet scaling:**
   ```bash
   for i in {1..5}; do
     ~/.sprite-mobile/create-sprite.sh sprite-$i
   done
   ```

3. **Claude-driven creation:**
   > "Create a new sprite called test-env and configure it with sprite-mobile"

## Breaking Changes

None. All changes are backward compatible:
- Interactive mode still works when no config file exists
- Manual config passing via `--config` still works
- Existing workflows unchanged

## Future Improvements

- [ ] Support for custom setup steps
- [ ] Parallel sprite creation
- [ ] Health check after setup
- [ ] Rollback on failure