### PR TITLE
Fix sprite switch to use public URL for polling

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1494,7 +1494,7 @@
           try {
             const controller = new AbortController();
             const timeout = setTimeout(() => controller.abort(), 3000);
-            const res = await fetch(`${tailscaleUrl}/api/config`, {
+            const res = await fetch(`${publicUrl}/api/config`, {
               signal: controller.signal,
               cache: 'no-store'
             });


### PR DESCRIPTION
## Summary
- Fixed sprite-network modal to poll public URL instead of Tailscale URL when switching sprites
- This eliminates the 15-retry delay (45+ seconds) that was occurring

## Problem
When switching to a network sprite, the code was:
1. Waking the sprite via the public URL
2. Polling the Tailscale URL for readiness (with 15 retries)

Since the Tailscale URL wasn't accessible, it would fail all 15 times before succeeding, making the switch process very slow.

## Solution
Changed the polling to use the public URL (line 1497 in `public/app.js`), matching the wake call. This should make sprite switching much faster since it's polling the same URL that was successfully used to wake the sprite.

## Changes
- `public/app.js:1497`: Changed from `${tailscaleUrl}/api/config` to `${publicUrl}/api/config`