### PR TITLE
Pass --name to setup script in create-sprite.sh

### DIFF
--- a/CREATE_SPRITE.md
+++ b/CREATE_SPRITE.md
@@ -47,10 +47,10 @@ The setup script now automatically detects `~/.sprite-config` and enables non-in
 
 ```bash
 # Old way (manual)
-set -a && source ~/.sprite-config && set +a && export NON_INTERACTIVE=true && ~/sprite-setup.sh all
+set -a && source ~/.sprite-config && set +a && export NON_INTERACTIVE=true && ~/sprite-setup.sh --name <sprite-name> all
 
-# New way (automatic)
-~/sprite-setup.sh all
+# New way (automatic, config auto-detected)
+~/sprite-setup.sh --name <sprite-name> all
 ```
 
 If `~/.sprite-config` exists, the script will:
@@ -83,8 +83,9 @@ The `create-sprite.sh` script follows this flow:
    - curl sprite-setup.sh to new sprite
 
 6. Run setup
-   - sprite exec -- ./sprite-setup.sh all
+   - sprite exec -- ./sprite-setup.sh --name <sprite-name> all
    - Auto-detects ~/.sprite-config
+   - Sets hostname to sprite name
    - Runs completely non-interactively
 
 7. Verify
@@ -194,7 +195,7 @@ cat ~/.sprite-config | sprite -s my-sprite exec -- cat > ~/.sprite-config
 sprite -s my-sprite exec -- bash -c "
   curl -fsSL https://gist.githubusercontent.com/clouvet/901dabc09e62648fa394af65ad004d04/raw/sprite-setup.sh -o ~/sprite-setup.sh
   chmod +x ~/sprite-setup.sh
-  ~/sprite-setup.sh all
+  ~/sprite-setup.sh --name my-sprite all
 "
 ```
 

--- a/create-sprite.sh
+++ b/create-sprite.sh
@@ -92,7 +92,7 @@ echo ""
 # Step 5: Run setup script
 echo "Step 5: Running setup script (this may take 3-5 minutes)..."
 echo ""
-sprite -s "$SPRITE_NAME" -o "$ORG" exec -- bash -c "set -a && source ~/.sprite-config && set +a && export NON_INTERACTIVE=true && cd ~ && ./sprite-setup.sh all"
+sprite -s "$SPRITE_NAME" -o "$ORG" exec -- bash -c "set -a && source ~/.sprite-config && set +a && export NON_INTERACTIVE=true && cd ~ && ./sprite-setup.sh --name '$SPRITE_NAME' all"
 echo ""
 
 # Step 6: Verify services


### PR DESCRIPTION
## Problem

The `create-sprite.sh` helper script wasn't passing the sprite name to the setup script. This meant the new hostname detection feature (from #30) couldn't reliably determine the sprite name.

Without `--name`, the setup script would try to:
1. ❌ Check `--name` argument (not provided)
2. ❌ Extract from `SPRITE_PUBLIC_URL` in transferred config (contains **source** sprite's URL, not new sprite's)
3. ✓ Fall back to `sprite whoami` (might work, but unreliable)

## Solution

Pass `--name $SPRITE_NAME` to the setup script in `create-sprite.sh`, and update documentation to match.

## Changes

### create-sprite.sh
```diff
- ./sprite-setup.sh all
+ ./sprite-setup.sh --name '$SPRITE_NAME' all
```

### CREATE_SPRITE.md
Updated all examples to include `--name <sprite-name>` flag:
- Flow documentation (step 6)
- Auto-detection examples
- Manual alternative examples

## Benefits

✅ **Reliable hostname detection** - Uses priority detection method
✅ **Correct hostname from start** - New sprites get proper hostname (e.g., `sad-clown` instead of `sprite`)
✅ **Documentation accuracy** - Examples match actual behavior
✅ **Consistent behavior** - Works the same way every time

## Testing

The changes ensure that when running:
```bash
./create-sprite.sh my-new-sprite
```

The setup script receives `--name my-new-sprite`, which:
1. Sets hostname to `my-new-sprite` immediately
2. Enables proper auto-detection of public URL
3. Matches sprite name consistently across environment

## Related

- Builds on #30 (hostname detection feature)
- Completes the automated sprite creation workflow