### PR TITLE
Improve hostname detection and sprite name display

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -290,7 +290,7 @@
 
       if (cachedConfig?.publicUrl) {
         spritePublicUrl = cachedConfig.publicUrl;
-        updateSpriteName(getSpriteNameFromUrl(spritePublicUrl));
+        updateSpriteName(cachedConfig.spriteName || getSpriteNameFromUrl(spritePublicUrl));
         wakeLog('Pinging: ' + spritePublicUrl);
 
         // Ping the public URL to wake the sprite
@@ -307,7 +307,7 @@
         if (config) {
           wakeLog('Sprite responded!');
           spritePublicUrl = config.publicUrl;
-          updateSpriteName(getSpriteNameFromUrl(spritePublicUrl));
+          updateSpriteName(config.spriteName || getSpriteNameFromUrl(spritePublicUrl));
           cacheConfig(config);
           startPublicKeepalive();
           return true;
@@ -323,7 +323,7 @@
         if (config?.publicUrl) {
           wakeLog('Direct connection OK');
           spritePublicUrl = config.publicUrl;
-          updateSpriteName(getSpriteNameFromUrl(spritePublicUrl));
+          updateSpriteName(config.spriteName || getSpriteNameFromUrl(spritePublicUrl));
           cacheConfig(config);
           startPublicKeepalive();
           return true;

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Sprite Code PWA
 // Caches shell for offline-first loading and stores public URL for sprite wake-up
 
-const CACHE_VERSION = 'v27';
+const CACHE_VERSION = 'v28';
 const SHELL_CACHE = `shell-${CACHE_VERSION}`;
 const CONFIG_CACHE = `config-${CACHE_VERSION}`;
 

--- a/routes/api.ts
+++ b/routes/api.ts
@@ -172,6 +172,7 @@ export function handleApi(req: Request, url: URL): Response | Promise<Response> 
   if (req.method === "GET" && path === "/api/config") {
     return Response.json({
       publicUrl: process.env.SPRITE_PUBLIC_URL || "",
+      spriteName: getHostname(),
     });
   }
 


### PR DESCRIPTION
## Summary
- Uses actual hostname instead of URL subdomain for sprite name display in the UI
- Fixes hostname detection and update logic in the setup script
- Cleans up /etc/hosts to remove old "sprite" entries
- Updates hostname in correct order to avoid "unable to resolve host" errors

## Changes

### Setup Script (`scripts/sprite-setup.sh`)
- Extract sprite name from `SPRITE_PUBLIC_URL` before hostname check (removes invalid `sprite whoami` command)
- Update hostname change logic to modify `/etc/hosts` first, then `/etc/hostname`, then `sudo hostname`
- Add cleanup logic when hostname is already changed to remove old "sprite" entries from `/etc/hosts`
- Skip GitHub repo prompt if `SPRITE_MOBILE_REPO` is already set

### API (`routes/api.ts`)
- Add `spriteName` field to `/api/config` endpoint that returns `getHostname()`

### UI (`public/app.js`)
- Update all sprite name initialization to use `config.spriteName` first, falling back to URL extraction
- Ensures sprite name matches hostname even when public URL subdomain differs

### Service Worker (`public/sw.js`)
- Bump cache version to v28

## Test plan
- [x] Run setup script with hostname "sprite" - should detect and update properly
- [x] Run setup script with hostname already set - should clean up /etc/hosts
- [x] Verify sprite name displays correctly in UI (matches hostname, not URL)
- [x] Verify no "unable to resolve host" errors during hostname change