### PR TITLE
Enable autocorrect and spellcheck for mobile input

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -104,7 +104,7 @@
             </svg>
           </button>
           <input type="file" id="file-input" accept="image/*" hidden>
-          <textarea id="input" placeholder="Message Claude..." rows="1" enterkeyhint="send" autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false"></textarea>
+          <textarea id="input" placeholder="Message Claude..." rows="1" enterkeyhint="send" autocomplete="off" autocorrect="on" autocapitalize="sentences" spellcheck="true"></textarea>
           <button id="send" disabled>
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
               <line x1="22" y1="2" x2="11" y2="13"></line>


### PR DESCRIPTION
## Problem
Mobile devices weren't showing autocorrect suggestions when typing messages, making it harder to type on phones/tablets.

## Solution
Changed the textarea input field settings:
- `autocorrect="off"` → `autocorrect="on"`
- `spellcheck="false"` → `spellcheck="true"`

## Impact
- Mobile users will now get native keyboard autocorrect suggestions
- Spellcheck will highlight misspelled words
- Desktop users are unaffected
- `autocomplete="off"` remains disabled to prevent browser form autocomplete (which is different from autocorrect)

## Testing
Tested on iOS Safari and Android Chrome to verify autocorrect suggestions appear while typing.