### PR TITLE
Fix paragraph breaks in user messages

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -828,9 +828,11 @@
       if (imageUrl) {
         imageHtml = `<img src="${imageUrl}" class="message-image" style="max-width: 200px; max-height: 200px; border-radius: 8px; margin-bottom: 8px; display: block;">`;
       }
+      // Escape HTML but preserve newlines by converting them to <br> tags
+      const formattedText = text ? escapeHtml(text).replace(/\n/g, '<br>') : '';
       msg.innerHTML = `
         <div class="message-header">You</div>
-        <div class="message-content">${imageHtml}${text ? escapeHtml(text) : ''}</div>
+        <div class="message-content">${imageHtml}${formattedText}</div>
       `;
       messagesEl.appendChild(msg);
       scrollToBottom();

--- a/public/styles.css
+++ b/public/styles.css
@@ -409,6 +409,7 @@
     .message.user .message-content {
       background: var(--user-bg);
       border-bottom-right-radius: 4px;
+      white-space: pre-wrap;
     }
 
     .message.assistant .message-content {


### PR DESCRIPTION
## Summary
- Fixes paragraph breaks not showing in user messages
- User messages now properly display newlines by converting them to `<br>` tags
- Added `white-space: pre-wrap` CSS to preserve formatting

## Changes
- Modified `addUserMessage()` to convert escaped newlines to `<br>` tags
- Added `white-space: pre-wrap` style to `.message.user .message-content`

## Test plan
- Send a multi-paragraph message in the chat
- Verify paragraph breaks are preserved in the UI

🤖 Generated with Claude Code