### PR TITLE
Production improvements for new sprite setup

### DIFF
--- a/scripts/sprite-setup.sh
+++ b/scripts/sprite-setup.sh
@@ -1446,7 +1446,7 @@ const html = \`<!DOCTYPE html>
         iframe.style.display = 'none';
         unauthorized.classList.add('visible');
       }
-    }, 8000); // 8 second timeout
+    }, 12000); // 12 second timeout
 
     // Update iframe when outer hash changes
     window.addEventListener('hashchange', () => {
@@ -1840,11 +1840,11 @@ run_all_steps() {
     step_5_flyctl
     step_7_tailscale
     step_9_tailscale_serve
+    step_12_claude_hub
     step_8_sprite_mobile
     step_6_5_network
     step_10_tailnet_gate
     step_11_claude_md
-    step_12_claude_hub
 
     # Final restart of sprite-mobile to pick up all environment changes
     echo ""

--- a/scripts/start-service.sh
+++ b/scripts/start-service.sh
@@ -14,5 +14,8 @@ if [ -f "$HOME/.sprite-mobile/.env" ]; then
     chmod 600 "$HOME/.sprite-mobile/.env"
 fi
 
+# Enable Go hub for multi-client sync
+export USE_GO_HUB=true
+
 # Start the service without hot-reload to prevent refreshes during conversations
 exec bun "$HOME/.sprite-mobile/server.ts"


### PR DESCRIPTION
## Overview

This PR includes 5 production improvements based on testing with new sprites:

1. **Increase tailnet-gate timeout (8s → 12s)**
2. **Enable claude-hub by default**
3. **Move setup docs to top of README**
4. **Reorder setup steps (claude-hub before sprite-mobile)**
5. **Sync session IDs with Claude's UUID**

## Changes

### 1. Tailnet Gate Timeout: 8 → 12 Seconds

**File:** `scripts/sprite-setup.sh`

Increases the iframe load timeout from 8 to 12 seconds. This gives slower connections more time to load the Tailscale URL before showing the "Unauthorized" screen.

```js
}, 12000); // 12 second timeout (was 8000)
```

### 2. Enable GO_HUB by Default

**File:** `scripts/start-service.sh`

Adds `export USE_GO_HUB=true` to the service startup script. This means all new sprites will use claude-hub for multi-client session synchronization out of the box.

**Benefits:**
- Multi-client sync works immediately
- Web ↔ terminal switching enabled by default
- No manual configuration needed

### 3. Move Setup Section to Top

**File:** `README.md`

Moved "Sprite Setup" and "Sprite Orchestration" sections from middle of README to immediately after the Table of Contents.

**Rationale:**
- Setup is the first thing new users need
- Better discoverability
- Follows "getting started first" documentation pattern

### 4. Reorder Setup Steps

**File:** `scripts/sprite-setup.sh`

Changed step execution order:
```diff
  step_7_tailscale
  step_9_tailscale_serve
+ step_12_claude_hub
  step_8_sprite_mobile
  step_6_5_network
  step_10_tailnet_gate
  step_11_claude_md
- step_12_claude_hub
```

**Rationale:**
- claude-hub must be running before sprite-mobile starts
- sprite-mobile connects to claude-hub on startup (when USE_GO_HUB=true)
- Prevents startup errors

Updated README step list to match.

### 5. Session ID Synchronization

**Files:** 
- `public/app.js` - Frontend session ID sync
- `routes/api.ts` - Backend session ID update endpoint
- `~/.claude-hub/internal/hub/hub.go` - Don't force UUID (separate repo)

**The Problem:**
When creating a new chat, sprite-mobile generated a random UUID, while Claude generated its own separate UUID. This created confusion:
- Browser URL: `#/session/abc-123`
- Claude session: `xyz-789.jsonl`
- User question: "Which UUID do I use with `claude --resume`?"

**The Solution:**
When Claude starts and sends its init message with its session UUID, sprite-mobile now:
1. Detects the UUID mismatch
2. Updates the frontend session ID to match Claude's UUID
3. Updates the browser URL hash
4. Calls backend API to rename session files
5. Backend renames session in sessions list, message files, and process map

**Result - ONE ID:**
- Browser URL: `#/session/abc-123`
- Claude session: `abc-123.jsonl`
- CLI resume: `claude --resume abc-123` ✅ (works!)

**Flow:**
```
User clicks "New Chat"
  ↓
sprite-mobile generates temp ID: temp-456
  ↓
WebSocket connects, Claude spawns
  ↓
Claude generates its UUID: abc-123
  ↓
Init message: { type: "system", subtype: "init", session_id: "abc-123" }
  ↓
Frontend detects mismatch (temp-456 != abc-123)
  ↓
Updates session ID to abc-123, changes URL hash
  ↓
Backend renames temp-456.json → abc-123.json
  ↓
ONE ID across the entire system!
```

**New API Endpoint:**
```
POST /api/sessions/:oldId/update-id
Body: { newId: "new-uuid" }

Returns: { success: true, oldId: "...", newId: "..." }
```

## Testing

Tested on a fresh sprite created via `create-sprite.sh`:
- ✅ Tailnet gate loads correctly (12s timeout sufficient)
- ✅ claude-hub service starts before sprite-mobile
- ✅ Multi-client sync works immediately
- ✅ Session ID from browser URL matches Claude's UUID
- ✅ `claude --resume <uuid-from-browser>` works perfectly
- ✅ Web and terminal sessions sync bidirectionally
- ✅ No more "exit status 1" errors from Claude

## Related Changes

claude-hub commits:
- `498ce4c` - (reverted) Attempted to force session ID
- `8a9ea3f` - Fixed: Don't force session ID for new Claude sessions

https://github.com/clouvet/claude-hub/commit/8a9ea3f

## Breaking Changes

None - all changes are backwards compatible. Existing sessions keep their IDs, only new sessions get synced to Claude's UUID.