### PR TITLE
Remove CLI session attachment feature

### DIFF
--- a/.claude/skills/sprite-mobile.md
+++ b/.claude/skills/sprite-mobile.md
@@ -623,7 +623,6 @@ This regenerates the tailnet-gate server with the current Tailscale serve URL.
 | DELETE | `/api/sessions/:id` | Delete session |
 | GET | `/api/sessions/:id/messages` | Get message history |
 | POST | `/api/sessions/:id/regenerate-title` | Regenerate session title |
-| GET | `/api/claude-sessions` | Discover CLI sessions from `~/.claude/projects/` |
 | POST | `/api/upload?session={id}` | Upload an image |
 | GET | `/api/uploads/:sessionId/:filename` | Retrieve uploaded image |
 | GET | `/api/sprites` | List saved Sprite profiles |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ sprite-mobile gives you a progressive web app chat UI for accessing Claude Code 
   - [WebSocket](#websocket)
   - [Keepalive](#keepalive)
 - [Session Lifecycle](#session-lifecycle)
-- [CLI Session Attachment](#cli-session-attachment)
 - [Configuration](#configuration)
 - [Security](#security)
 - [Troubleshooting](#troubleshooting)
@@ -230,7 +229,6 @@ Claude will have full context about sprite-mobile without needing to read throug
 - **Multiple Chat Sessions**: Create and manage multiple independent chat sessions, each with its own Claude Code process
 - **Persistent History**: Messages are saved to disk and survive server restarts
 - **Session Resume**: Reconnecting to a session resumes the existing Claude conversation
-- **CLI Session Attachment**: Attach to existing Claude CLI sessions started in the terminal and import their history
 - **Image Support**: Upload and send images to Claude for analysis (auto-resized for API limits)
 - **Real-time Streaming**: Responses stream in real-time via WebSocket
 - **Activity Indicators**: See exactly what Claude is doing (reading files, running commands, searching)
@@ -628,7 +626,6 @@ Claude's `.jsonl` files are the source of truth. Sprite-mobile only maintains li
 | DELETE | `/api/sessions/:id` | Delete session |
 | GET | `/api/sessions/:id/messages` | Get message history |
 | POST | `/api/sessions/:id/regenerate-title` | Regenerate session title |
-| GET | `/api/claude-sessions` | Discover Claude CLI sessions from `~/.claude/projects/` |
 | POST | `/api/upload?session={id}` | Upload an image |
 | GET | `/api/uploads/:sessionId/:filename` | Retrieve uploaded image |
 | GET | `/api/sprites` | List saved Sprite profiles |
@@ -724,42 +721,6 @@ If you close your browser while Claude is working:
 - Keep browser tab open (even in background)
 - Open terminal session: `sprite exec -s <sprite-name>` keeps sprite awake
 - Use distributed tasks to assign work to another sprite
-
-## CLI Session Attachment
-
-Sprite Mobile can attach to existing Claude CLI sessions that were started in the terminal. This allows you to:
-
-1. Continue conversations that you started on the command line
-2. Import the full conversation history into the web interface
-3. Switch between CLI and web interface seamlessly
-
-**How it works:**
-
-- Click the terminal icon in the sidebar (next to "New Chat")
-- The app discovers sessions from `~/.claude/projects/` directory
-- Select a session to import its history and resume the conversation
-- The session continues with the same Claude session ID, maintaining full context
-
-**Session discovery format:**
-
-Claude CLI stores sessions in `~/.claude/projects/{cwd}/{sessionId}.jsonl`. The app:
-- Scans all working directories under the projects folder
-- Parses `.jsonl` files to extract message history
-- Shows the first user message as a preview
-- Filters out empty sessions and internal tool messages
-
-**Important caveat (with claude-hub):**
-
-claude-hub manages transitions between web and terminal sessions using a state machine:
-
-- **Web-only mode**: claude-hub runs a headless Claude process
-- **Terminal detected**: claude-hub kills the headless process and monitors the terminal session
-- **Terminal exits**: claude-hub spawns headless process again
-
-**Potential race condition:**
-- During the transition window (terminal detection → killing headless), both processes could theoretically write to the same `.jsonl` file
-- claude-hub detects terminal sessions via file watching (fsnotify), not continuous polling
-- **Best practice**: Avoid actively using both terminal and web interface simultaneously on the same session to prevent potential file corruption during state transitions
 
 ## Configuration
 

--- a/public/app.js
+++ b/public/app.js
@@ -78,10 +78,6 @@
     const spritesSeparator = document.getElementById('sprites-separator');
     const wakingOverlay = document.getElementById('waking-overlay');
     const switchingOverlay = document.getElementById('switching-overlay');
-    const attachSessionBtn = document.getElementById('attach-session-btn');
-    const externalSessionsModal = document.getElementById('external-sessions-modal');
-    const closeExternalSessionsModal = document.getElementById('close-external-sessions-modal');
-    const externalSessionsList = document.getElementById('external-sessions-list');
 
     // State
     let sessions = [];
@@ -1784,87 +1780,6 @@
     });
     refreshTasksBtn.addEventListener('click', loadTasks);
 
-    // External sessions modal (attach to CLI sessions)
-    function openExternalSessionsModal() {
-      externalSessionsModal.classList.add('open');
-      loadExternalSessions();
-    }
-
-    function closeExternalSessionsModalFn() {
-      externalSessionsModal.classList.remove('open');
-    }
-
-    async function loadExternalSessions() {
-      externalSessionsList.innerHTML = '<div class="loading">Loading sessions...</div>';
-
-      try {
-        const res = await fetch('/api/claude-sessions');
-        const cliSessions = await res.json();
-
-        if (cliSessions.length === 0) {
-          externalSessionsList.innerHTML = '<div class="empty">No CLI sessions found</div>';
-          return;
-        }
-
-        externalSessionsList.innerHTML = cliSessions.map(s => `
-          <div class="external-session-item" data-session-id="${escapeHtml(s.sessionId)}" data-cwd="${escapeHtml(s.cwd)}">
-            <div class="session-preview">${escapeHtml(s.preview || 'No preview available')}</div>
-            <div class="session-cwd">${escapeHtml(s.cwd)}</div>
-            <div class="session-meta">
-              <span>${formatTime(s.lastModified)}</span>
-              <span>${formatSize(s.size)}</span>
-            </div>
-            <div class="session-id">${escapeHtml(s.sessionId)}</div>
-          </div>
-        `).join('');
-
-        // Add click handlers
-        externalSessionsList.querySelectorAll('.external-session-item').forEach(el => {
-          el.addEventListener('click', () => {
-            const sessionId = el.dataset.sessionId;
-            const cwd = el.dataset.cwd;
-            attachToExternalSession(sessionId, cwd);
-          });
-        });
-      } catch (err) {
-        console.error('Failed to load external sessions:', err);
-        externalSessionsList.innerHTML = '<div class="empty">Failed to load sessions</div>';
-      }
-    }
-
-    function formatSize(bytes) {
-      if (bytes < 1024) return bytes + ' B';
-      if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-      return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-    }
-
-    async function attachToExternalSession(claudeSessionId, cwd) {
-      closeExternalSessionsModalFn();
-      closeSidebar();
-
-      // Create a new session that attaches to the external Claude session
-      const res = await fetch('/api/sessions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: 'CLI Session',
-          cwd: cwd,
-          claudeSessionId: claudeSessionId,
-        }),
-      });
-      const session = await res.json();
-      sessions.unshift(session);
-      renderSessionsList();
-      selectSession(session);
-    }
-
-    // External sessions modal event listeners
-    attachSessionBtn.addEventListener('click', openExternalSessionsModal);
-    closeExternalSessionsModal.addEventListener('click', closeExternalSessionsModalFn);
-    externalSessionsModal.addEventListener('click', (e) => {
-      if (e.target === externalSessionsModal) closeExternalSessionsModalFn();
-    });
-
     let pullStartY = 0;
     let isPulling = false;
     let pullDistance = 0;
@@ -1876,7 +1791,6 @@
       // Only allow pull refresh when sidebar/modal are closed
       if (sidebar.classList.contains('open')) return false;
       if (spritesModal.classList.contains('open')) return false;
-      if (externalSessionsModal.classList.contains('open')) return false;
 
       // If started on header, always allow
       if (fromHeader || pullStartedOnHeader) return true;

--- a/public/index.html
+++ b/public/index.html
@@ -44,12 +44,6 @@
       <div id="sidebar-header">
         <h2>Chats</h2>
         <div id="sidebar-actions">
-          <button id="attach-session-btn" title="Attach to CLI Session">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="4 17 10 11 4 5"></polyline>
-              <line x1="12" y1="19" x2="20" y2="19"></line>
-            </svg>
-          </button>
           <button id="new-chat-btn" title="New Chat">+</button>
         </div>
       </div>
@@ -116,22 +110,6 @@
               <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
             </svg>
           </button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- External Sessions Modal -->
-  <div id="external-sessions-modal">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h2>Attach to CLI Session</h2>
-        <button class="modal-close" id="close-external-sessions-modal">×</button>
-      </div>
-      <div class="modal-body">
-        <p class="modal-description">Connect to a Claude session started in the terminal</p>
-        <div id="external-sessions-list" class="external-sessions-list">
-          <div class="loading">Loading sessions...</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Removes the CLI session attachment feature, which is no longer necessary since there's no real distinction between CLI sessions and web UI sessions. Both now use the same claude-hub backend for session management.

## Changes

### Documentation
- Removed "CLI Session Attachment" section from README
- Removed mention from Features list and Table of Contents
- Removed `/api/claude-sessions` endpoint from API documentation
- Updated .claude/skills/sprite-mobile.md

### Backend (routes/api.ts)
- Removed `CLAUDE_PROJECTS_DIR` constant
- Removed `discoverClaudeSessions()` function (60+ lines)
- Removed `parseCliSessionMessages()` function (70+ lines)
- Removed `GET /api/claude-sessions` endpoint
- Removed `claudeSessionId` support from `POST /api/sessions`
- Updated regenerate-title to use inline path instead of constant

### Frontend (public/app.js)
- Removed terminal icon button references
- Removed `openExternalSessionsModal()` function
- Removed `loadExternalSessions()` function
- Removed `attachToExternalSession()` function
- Removed `formatSize()` helper function
- Removed event listeners for external sessions modal

### HTML (public/index.html)
- Removed terminal icon button from sidebar
- Removed external sessions modal markup

## Impact

**Total lines removed:** 322 lines

This is a breaking change for users who were using the terminal icon button to attach to CLI sessions, but since CLI and web sessions are now unified through claude-hub, users can simply start a new session or use `claude --resume` from the terminal instead.