### PR TITLE
Replace loading text with spinning sprite emoji

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -452,7 +452,7 @@
 
     function renderSessionsList() {
       if (sessions.length === 0 && !sessionsLoaded) {
-        sessionsList.innerHTML = '<div class="loading">Loading chats...</div>';
+        sessionsList.innerHTML = '<div class="sessions-loading"><span class="sprite-emoji">👾</span></div>';
         return;
       }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -171,6 +171,27 @@
       color: var(--text-muted);
     }
 
+    .sessions-loading {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 32px 16px;
+    }
+
+    .sessions-loading .sprite-emoji {
+      font-size: 32px;
+      animation: spin-clockwise 2s linear infinite;
+    }
+
+    @keyframes spin-clockwise {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
     .session-delete {
       width: 36px;
       height: 36px;


### PR DESCRIPTION
## Change

Replaced the sidebar "Loading chats..." text indicator with a spinning sprite emoji (👾) for better visual consistency and alignment.

## Before
- Plain text: "Loading chats..."
- Misaligned and looked out of place

## After
- Centered spinning 👾 emoji
- 2-second clockwise rotation animation
- Properly aligned and visually consistent with the app's theme

## Implementation
- New `.sessions-loading` CSS class for centered layout
- `spin-clockwise` keyframe animation
- 32px emoji with 32px vertical padding