### PR TITLE
Add spinning sprite emoji inside loading circles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,9 @@
 <body>
   <!-- Waking overlay - shown while sprite is waking from suspension -->
   <div id="waking-overlay">
-    <div class="waking-spinner"></div>
+    <div class="waking-spinner">
+      <span class="spinner-sprite">👾</span>
+    </div>
     <div class="waking-text">Waking sprite...</div>
     <div class="waking-subtext">This may take a few seconds</div>
     <div id="waking-log"></div>
@@ -25,7 +27,9 @@
 
   <!-- Switching overlay - shown when switching to another sprite -->
   <div id="switching-overlay">
-    <div class="switching-spinner"></div>
+    <div class="switching-spinner">
+      <span class="spinner-sprite">👾</span>
+    </div>
     <div class="switching-text">Switching to sprite...</div>
     <div class="switching-subtext">Waking up the target sprite</div>
   </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1463,6 +1463,16 @@
       border-radius: 50%;
       animation: spin 1s linear infinite;
       margin-bottom: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+
+    .waking-spinner .spinner-sprite {
+      font-size: 20px;
+      animation: spin-clockwise 2s linear infinite;
+      position: absolute;
     }
 
     .waking-text {
@@ -1517,6 +1527,16 @@
       border-radius: 50%;
       animation: spin 1s linear infinite;
       margin-bottom: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+
+    .switching-spinner .spinner-sprite {
+      font-size: 20px;
+      animation: spin-clockwise 2s linear infinite;
+      position: absolute;
     }
 
     .switching-text {


### PR DESCRIPTION
## Change

Added the spinning sprite emoji (👾) inside the loading circle spinners for a more playful and consistent loading experience.

## Implementation

**HTML:**
- Added `<span class="spinner-sprite">👾</span>` inside both `.waking-spinner` and `.switching-spinner`

**CSS:**
- Made spinner divs flex containers to center the emoji
- Added `.spinner-sprite` styling with 20px font size
- Emoji spins clockwise at 2s using the existing `spin-clockwise` animation
- Border circle spins counter-clockwise at 1s
- Creates a nice double-spinning effect

## Visual Effect

- **Circle border**: Spins counter-clockwise at 1s
- **Sprite emoji**: Spins clockwise at 2s inside the circle
- Both animations run simultaneously for a dynamic effect

## Locations

Applied to both loading overlays:
- Waking overlay (when sprite is waking from suspension)
- Switching overlay (when switching to another sprite)