### PR TITLE
Add circle to sidebar loading spinner for consistency

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -452,7 +452,7 @@
 
     function renderSessionsList() {
       if (sessions.length === 0 && !sessionsLoaded) {
-        sessionsList.innerHTML = '<div class="sessions-loading"><span class="sprite-emoji">👾</span></div>';
+        sessionsList.innerHTML = '<div class="sessions-loading"><div class="sessions-spinner"><span class="spinner-sprite">👾</span></div></div>';
         return;
       }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -178,9 +178,23 @@
       padding: 32px 16px;
     }
 
-    .sessions-loading .sprite-emoji {
-      font-size: 32px;
+    .sessions-spinner {
+      width: 40px;
+      height: 40px;
+      border: 3px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+
+    .sessions-spinner .spinner-sprite {
+      font-size: 20px;
       animation: spin-clockwise 2s linear infinite;
+      position: absolute;
     }
 
     @keyframes spin-clockwise {


### PR DESCRIPTION
## Problem

The sidebar loading indicator was just a spinning sprite emoji without a circle, while all other loading indicators in the app have the double-spinning effect (circle + sprite).

## Solution

Updated the sidebar loading spinner to match all other spinners:
- 40px circle border (spins counter-clockwise at 1s)
- 20px sprite emoji inside (spins clockwise at 2s)
- Same visual pattern as waking/switching overlays

## Changes

**HTML (app.js):**
- Changed from `<span class="sprite-emoji">👾</span>` 
- To `<div class="sessions-spinner"><span class="spinner-sprite">👾</span></div>`

**CSS:**
- Replaced `.sprite-emoji` styling with `.sessions-spinner`
- Added circle border with animation
- Centered sprite inside using flexbox

## Result

Now **all** loading indicators have the consistent double-spinning effect:
- ✅ Waking overlay
- ✅ Switching sprites overlay
- ✅ Pull-to-refresh
- ✅ Activity/tool indicators
- ✅ Sidebar loading (fixed)