### PR TITLE
Fix button clicks causing input blur

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1282,11 +1282,15 @@
     });
 
     inputEl.addEventListener('blur', () => {
-      // Only remove focused class if input is empty
-      // Keep it focused if there's text or an image
-      if (!inputEl.value.trim() && !pendingImage) {
-        inputArea.classList.remove('focused');
-      }
+      // Small delay to allow button clicks to process first
+      // This prevents buttons from becoming non-functional when input blurs
+      setTimeout(() => {
+        // Only remove focused class if input is empty
+        // Keep it focused if there's text or an image
+        if (!inputEl.value.trim() && !pendingImage) {
+          inputArea.classList.remove('focused');
+        }
+      }, 100);
     });
 
     sendBtn.addEventListener('click', send);


### PR DESCRIPTION
## Critical Fix

Fixes buttons (mic, attach) not working when input is focused.

## Problem

When input was focused and user tapped action buttons:
- Input would blur immediately
- Blur handler would remove  class
- Button click event would fire but buttons were already hidden
- Result: Buttons appeared broken, didn't do anything

## Solution

Add 100ms timeout in blur handler before checking if we should collapse. This gives button click events time to fire and process before we decide to remove the focused state.

## Testing

- [x] Tap input to focus
- [x] Tap mic button → works correctly
- [x] Tap attach button → works correctly
- [x] Click outside input with no text → still collapses properly
- [x] 100ms delay is imperceptible to users

🤖 Generated with [Claude Code](https://claude.com/claude-code)