### PR TITLE
Fix attach button iOS file picker positioning

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -92,6 +92,7 @@
     let pendingImage = null; // { id, filename, mediaType, url, localUrl }
     let isEditingTitle = false;
     let messageCountSinceLastTitleUpdate = 0;
+    let isOpeningFilePicker = false; // Track when file picker is opening
 
     // Detect if we're on a desktop device (has precise pointer like mouse/trackpad)
     function isDesktop() {
@@ -1285,6 +1286,9 @@
       // Small delay to allow button clicks to process first
       // This prevents buttons from becoming non-functional when input blurs
       setTimeout(() => {
+        // Don't collapse if file picker is opening
+        if (isOpeningFilePicker) return;
+
         // Only remove focused class if input is empty
         // Keep it focused if there's text or an image
         if (!inputEl.value.trim() && !pendingImage) {
@@ -1299,8 +1303,16 @@
     startChatBtn.addEventListener('click', () => createSession());
 
     // Image upload handlers
-    attachBtn.addEventListener('click', () => fileInput.click());
+    attachBtn.addEventListener('click', () => {
+      isOpeningFilePicker = true;
+      fileInput.click();
+      // Clear flag after a short delay (file picker has opened or was blocked)
+      setTimeout(() => {
+        isOpeningFilePicker = false;
+      }, 300);
+    });
     fileInput.addEventListener('change', (e) => {
+      isOpeningFilePicker = false; // Clear flag when file is selected
       const file = e.target.files?.[0];
       if (file) {
         uploadImage(file);


### PR DESCRIPTION
## Critical Fix

Fixes iOS file picker appearing in wrong position when attach button clicked.

## Problem

1. User taps attach button
2. Input blurs immediately
3. Blur handler collapses UI after 100ms
4. iOS file picker opens in middle of screen (where button was before collapse)
5. Confusing UX - file picker floating in wrong spot

## Solution

Track when file picker is opening with `isOpeningFilePicker` flag:
- Set flag when attach button clicked
- Prevent blur handler from collapsing while flag is true
- Clear flag when file selected OR after 300ms timeout

Now file picker opens with buttons still visible in correct position.

## Testing

- [x] Tap attach button → file picker opens in correct position
- [x] Select file → works normally
- [x] Cancel file picker → UI behaves correctly
- [x] Normal blur behavior unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)