### PR TITLE
Prevent mic and attach buttons from blurring input

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1302,6 +1302,14 @@
     newChatBtn.addEventListener('click', () => createSession());
     startChatBtn.addEventListener('click', () => createSession());
 
+    // Prevent action buttons from causing input blur
+    // Use mousedown/touchstart preventDefault to keep input focused
+    [attachBtn, micBtn].forEach(btn => {
+      btn.addEventListener('mousedown', (e) => {
+        e.preventDefault(); // Prevent focus shift from input
+      });
+    });
+
     // Image upload handlers
     attachBtn.addEventListener('click', () => {
       isOpeningFilePicker = true;


### PR DESCRIPTION
Final fix for button blur issue - prevents mic and attach buttons from causing input blur entirely using mousedown preventDefault. Input stays focused when clicking buttons, buttons remain visible and functional.