### PR TITLE
Fix stop and send buttons not working when input focused

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2003,7 +2003,7 @@
 
     // Prevent action buttons from causing input blur
     // Use mousedown preventDefault to keep input focused
-    [attachBtn, micBtn].forEach(btn => {
+    [attachBtn, micBtn, sendBtn, stopBtn].forEach(btn => {
       btn.addEventListener('mousedown', (e) => {
         e.preventDefault(); // Prevent focus shift from input
       });


### PR DESCRIPTION
Problem: Stop and send buttons don't work correctly when clicked while input is focused. The buttons blur the input before the click event can properly fire, causing the UI to collapse and the action to fail or not communicate properly with Claude.

Root cause: mousedown preventDefault was only applied to attachBtn and micBtn (from PR #64 and #65) but not to sendBtn and stopBtn.

Solution: Add sendBtn and stopBtn to the array of buttons that prevent input blur on mousedown.

Now all action buttons (attach, mic, send, stop) properly prevent input blur, keeping the UI stable and ensuring button clicks work correctly even when input is focused.

## Testing
- Click stop button while input is focused - should send interrupt signal
- Click send button while input is focused - should send message
- Input should stay focused after clicking any action button
- UI should remain stable during button interactions