### PR TITLE
Handle isGenerating flag in history for multi-client sync

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -661,7 +661,7 @@
 
         case 'history':
           // Render stored message history - clear first to avoid duplicates
-          console.log('[Client] Received history:', msg.messages?.length, 'messages');
+          console.log('[Client] Received history:', msg.messages?.length, 'messages', 'isGenerating:', msg.isGenerating);
           if (msg.messages && Array.isArray(msg.messages)) {
             messagesEl.innerHTML = '';
             currentAssistantMessage = null;
@@ -676,6 +676,13 @@
               }
             }
             console.log('[Client] Rendered', msg.messages.length, 'messages from history');
+
+            // If Claude is currently generating, show the thinking indicator
+            // and prepare to receive streaming content
+            if (msg.isGenerating) {
+              console.log('[Client] Claude is generating, preparing for streaming updates');
+              showThinkingIndicator();
+            }
           }
           break;
 


### PR DESCRIPTION
## Problem

When a second device joins a chat session while Claude is actively generating, the client would receive history but not be properly prepared to receive streaming updates, causing synchronization issues.

## Solution

### Client-side changes (app.js):
- Handle the `isGenerating` flag in the history message
- Show thinking indicator when history loads with `isGenerating: true`
- This prepares the client to properly receive and render streaming content

## Testing

1. Open chat on Device A (desktop)
2. Send a message and wait for Claude to start responding
3. While responding, open the same chat on Device B (phone)
4. Device B should see:
   - All history messages
   - Thinking indicator appears
   - Streaming response continues in real-time
5. Both devices stay synchronized

## Related

Works with clouvet/claude-hub#2 which provides the `isGenerating` flag in history messages.

## Note

Users need to refresh their browsers to get the updated client code after this is deployed.