### PR TITLE
Session memories - per-session markdown summaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,15 @@ The skill covers:
 - API endpoints and WebSocket protocol
 - Common troubleshooting tasks
 
+## Session Memories
+
+Per-session memory summaries are stored as markdown files in `data/memories/`. Each file is named `{sessionId}.md` and contains a YAML frontmatter block (title, session ID, date) followed by a markdown summary of what was discussed, decided, and built in that session.
+
+To review past work, read the files in `data/memories/`. You can also use the API:
+- `GET /api/memories` — list all memories
+- `GET /api/memories/:id` — read a specific memory
+- `POST /api/memories/:id/generate` — auto-generate a summary from the conversation
+
 ## Git Commits
 
 Do NOT add "Co-Authored-By" lines to commit messages. Just write normal commit messages without any co-author attribution.

--- a/lib/claude.ts
+++ b/lib/claude.ts
@@ -6,10 +6,13 @@ export async function generateChatName(message: string, sessionId: string): Prom
   try {
     const prompt = `Generate a very short title (3-5 words max) for a chat that starts with this message. Reply with ONLY the title, no quotes or punctuation:\n\n${message.slice(0, 500)}`;
 
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
     const proc = spawn({
       cmd: ["claude", "--print", "-p", prompt],
       stdout: "pipe",
       stderr: "pipe",
+      env,
     });
 
     const output = await new Response(proc.stdout).text();

--- a/lib/memory.ts
+++ b/lib/memory.ts
@@ -1,0 +1,193 @@
+import { spawn } from "bun";
+import { readFileSync, writeFileSync, existsSync, unlinkSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import { MEMORIES_DIR } from "./storage";
+
+export interface MemoryMeta {
+  sessionId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  size: number;
+}
+
+// Parse frontmatter from a memory markdown file
+function parseFrontmatter(content: string): { meta: Record<string, string>; body: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { meta: {}, body: content };
+
+  const meta: Record<string, string> = {};
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx > 0) {
+      meta[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+    }
+  }
+  return { meta, body: match[2] };
+}
+
+function memoryPath(sessionId: string): string {
+  return join(MEMORIES_DIR, `${sessionId}.md`);
+}
+
+// List all memories with metadata
+export function listMemories(): MemoryMeta[] {
+
+  const files = readdirSync(MEMORIES_DIR).filter(f => f.endsWith(".md"));
+  return files.map(f => {
+    const sessionId = f.replace(".md", "");
+    const filePath = join(MEMORIES_DIR, f);
+    const content = readFileSync(filePath, "utf-8");
+    const stat = statSync(filePath);
+    const { meta } = parseFrontmatter(content);
+    return {
+      sessionId,
+      title: meta.title || sessionId,
+      createdAt: meta.created || stat.birthtime.toISOString(),
+      updatedAt: stat.mtime.toISOString(),
+      size: stat.size,
+    };
+  }).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+}
+
+// Get a specific memory
+export function getMemory(sessionId: string): string | null {
+  const path = memoryPath(sessionId);
+  if (!existsSync(path)) return null;
+  return readFileSync(path, "utf-8");
+}
+
+// Save a memory
+export function saveMemory(sessionId: string, content: string): void {
+
+  writeFileSync(memoryPath(sessionId), content);
+}
+
+// Delete a memory
+export function deleteMemory(sessionId: string): boolean {
+  const path = memoryPath(sessionId);
+  if (!existsSync(path)) return false;
+  unlinkSync(path);
+  return true;
+}
+
+// Get combined context from multiple sessions
+export function getCombinedContext(sessionIds: string[]): string {
+  const parts: string[] = [];
+  for (const id of sessionIds) {
+    const content = getMemory(id);
+    if (content) {
+      parts.push(content);
+    }
+  }
+  return parts.join("\n\n---\n\n");
+}
+
+// Read a session's .jsonl conversation and extract messages
+function readSessionConversation(sessionId: string): Array<{ role: string; content: string }> {
+  const homeDir = process.env.HOME || "/home/sprite";
+  const claudeProjectsDir = join(homeDir, ".claude", "projects");
+
+  if (!existsSync(claudeProjectsDir)) return [];
+
+  // Scan all cwd directories for the session file
+  let jsonlPath: string | null = null;
+  try {
+    const cwdDirs = readdirSync(claudeProjectsDir);
+    for (const cwdDir of cwdDirs) {
+      const candidate = join(claudeProjectsDir, cwdDir, `${sessionId}.jsonl`);
+      if (existsSync(candidate)) {
+        jsonlPath = candidate;
+        break;
+      }
+    }
+  } catch {}
+
+  if (!jsonlPath) return [];
+
+  const messages: Array<{ role: string; content: string }> = [];
+  try {
+    const content = readFileSync(jsonlPath, "utf-8");
+    for (const line of content.trim().split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.type === "user" && msg.message?.content) {
+          const c = msg.message.content;
+          const text = typeof c === "string"
+            ? c
+            : Array.isArray(c)
+              ? c.filter((b: any) => b.type === "text").map((b: any) => b.text).join(" ")
+              : "";
+          if (text) messages.push({ role: "user", content: text });
+        }
+        if (msg.type === "assistant" && msg.message?.content) {
+          const text = Array.isArray(msg.message.content)
+            ? msg.message.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("\n")
+            : "";
+          if (text) messages.push({ role: "assistant", content: text });
+        }
+      } catch {}
+    }
+  } catch {}
+
+  return messages;
+}
+
+// Generate a memory summary for a session using Claude
+export async function generateMemory(sessionId: string, sessionTitle: string): Promise<string> {
+  const messages = readSessionConversation(sessionId);
+  if (messages.length === 0) {
+    throw new Error("No conversation found for this session");
+  }
+
+  // Build conversation excerpt (truncate long messages, limit total size)
+  const excerpt = messages.map(m => {
+    const truncated = m.content.length > 500 ? m.content.slice(0, 500) + "..." : m.content;
+    return `${m.role}: ${truncated}`;
+  }).join("\n\n");
+
+  // Cap at ~8000 chars to keep the prompt reasonable
+  const truncatedExcerpt = excerpt.slice(0, 8000);
+
+  const prompt = `Summarize this conversation into a concise memory document. Include:
+- What was discussed (key topics)
+- What was decided or built
+- Important outcomes, file paths, or technical details worth remembering
+- Any open items or follow-ups
+
+Write in markdown. Be concise but preserve important details. Use bullet points.
+Do NOT include a frontmatter block — just the markdown body.
+
+Conversation:
+${truncatedExcerpt}`;
+
+  const env = { ...process.env };
+  delete env.CLAUDECODE;
+  const proc = spawn({
+    cmd: ["claude", "--print", "-p", prompt],
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const output = await new Response(proc.stdout).text();
+  const body = output.trim();
+
+  if (!body) {
+    throw new Error("Claude returned empty summary");
+  }
+
+  // Build the memory file with frontmatter
+  const now = new Date().toISOString();
+  const memory = `---
+title: ${sessionTitle}
+session: ${sessionId}
+created: ${now}
+---
+${body}
+`;
+
+  saveMemory(sessionId, memory);
+  return memory;
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -9,11 +9,14 @@ export const UPLOADS_DIR = join(DATA_DIR, "uploads");
 const SESSIONS_FILE = join(DATA_DIR, "sessions.json");
 const SPRITES_FILE = join(DATA_DIR, "sprites.json");
 
+export const MEMORIES_DIR = join(DATA_DIR, "memories");
+
 // Ensure directories exist
 export function ensureDirectories() {
   if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
   if (!existsSync(MESSAGES_DIR)) mkdirSync(MESSAGES_DIR, { recursive: true });
   if (!existsSync(UPLOADS_DIR)) mkdirSync(UPLOADS_DIR, { recursive: true });
+  if (!existsSync(MEMORIES_DIR)) mkdirSync(MEMORIES_DIR, { recursive: true });
 }
 
 // Generate UUID

--- a/routes/api.ts
+++ b/routes/api.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/storage";
 import type { StoredMessage } from "../lib/types";
 import { discoverSprites, getSpriteStatus, getNetworkInfo, getHostname, updateHeartbeat, deleteSprite } from "../lib/network";
+import { listMemories, getMemory, saveMemory, deleteMemory, getCombinedContext, generateMemory } from "../lib/memory";
 import { allClients } from "./websocket";
 
 // Broadcast a message to all connected keepalive clients
@@ -207,10 +208,13 @@ export function handleApi(req: Request, url: URL): Response | Promise<Response> 
       try {
         const prompt = `Based on this conversation, generate a very short title (3-5 words max) that captures the main topic. Reply with ONLY the title, no quotes or punctuation:\n\n${conversationSummary.slice(0, 1500)}`;
 
+        const env = { ...process.env };
+        delete env.CLAUDECODE;
         const proc = spawn({
           cmd: ["claude", "--print", "-p", prompt],
           stdout: "pipe",
           stderr: "pipe",
+          env,
         });
 
         const output = await new Response(proc.stdout).text();
@@ -519,6 +523,68 @@ export function handleApi(req: Request, url: URL): Response | Promise<Response> 
     } catch {
       return new Response("Not found", { status: 404 });
     }
+  }
+
+  // === Session Memories ===
+
+  // GET /api/memories - List all memories
+  if (req.method === "GET" && path === "/api/memories") {
+    const memories = listMemories();
+    return Response.json(memories);
+  }
+
+  // POST /api/memories/context - Get combined context from selected sessions
+  if (req.method === "POST" && path === "/api/memories/context") {
+    return (async () => {
+      const body = await req.json().catch(() => ({})) as { sessionIds?: string[] };
+      if (!body.sessionIds || !Array.isArray(body.sessionIds)) {
+        return new Response("sessionIds array required", { status: 400 });
+      }
+      const context = getCombinedContext(body.sessionIds);
+      return Response.json({ context });
+    })();
+  }
+
+  // GET /api/memories/:id - Get a specific memory
+  if (req.method === "GET" && path.match(/^\/api\/memories\/[^/]+$/)) {
+    const id = path.split("/")[3];
+    const content = getMemory(id);
+    if (!content) return new Response("Not found", { status: 404 });
+    return new Response(content, { headers: { "Content-Type": "text/markdown" } });
+  }
+
+  // PUT /api/memories/:id - Save/update a memory manually
+  if (req.method === "PUT" && path.match(/^\/api\/memories\/[^/]+$/)) {
+    return (async () => {
+      const id = path.split("/")[3];
+      const content = await req.text();
+      if (!content.trim()) return new Response("Content required", { status: 400 });
+      saveMemory(id, content);
+      return Response.json({ success: true, sessionId: id });
+    })();
+  }
+
+  // POST /api/memories/:id/generate - Auto-generate memory from conversation
+  if (req.method === "POST" && path.match(/^\/api\/memories\/[^/]+\/generate$/)) {
+    return (async () => {
+      const id = path.split("/")[3];
+      const session = getSession(id);
+      const title = session?.name || id;
+      try {
+        const memory = await generateMemory(id, title);
+        return Response.json({ success: true, sessionId: id, content: memory });
+      } catch (err: any) {
+        return Response.json({ error: err.message }, { status: 400 });
+      }
+    })();
+  }
+
+  // DELETE /api/memories/:id - Delete a memory
+  if (req.method === "DELETE" && path.match(/^\/api\/memories\/[^/]+$/)) {
+    const id = path.split("/")[3];
+    const deleted = deleteMemory(id);
+    if (!deleted) return new Response("Not found", { status: 404 });
+    return new Response(null, { status: 204 });
   }
 
   // GET /api/keepalive/status - Check if keepalive process is running

--- a/server.ts
+++ b/server.ts
@@ -56,6 +56,7 @@ function getContentType(path: string): string {
 // Start server
 const server = Bun.serve({
   port: PORT,
+  idleTimeout: 120, // seconds - needed for Claude summarization endpoints
 
   async fetch(req, server) {
     const url = new URL(req.url);


### PR DESCRIPTION
## Summary

- **Per-session memory files** stored as markdown in `data/memories/{sessionId}.md` with YAML frontmatter (title, session ID, creation date)
- **Auto-generate** memory summaries from Claude `.jsonl` conversation files using `claude --print`
- **Combine context** from multiple sessions for injection into new chats
- **CRUD API** for managing memories manually or programmatically
- **Bug fix**: unset `CLAUDECODE` env var when spawning Claude subprocesses (fixes nested session error)
- **Bug fix**: increase `idleTimeout` to 120s for long-running summarization requests

Inspired by [OpenClaw's memory system](https://velvetshark.com/openclaw-memory-masterclass) — file-based markdown memories with per-session summaries.

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/memories` | List all memories with metadata |
| `GET` | `/api/memories/:id` | Read a specific memory (markdown) |
| `PUT` | `/api/memories/:id` | Save/update a memory manually |
| `POST` | `/api/memories/:id/generate` | Auto-generate from conversation |
| `DELETE` | `/api/memories/:id` | Delete a memory |
| `POST` | `/api/memories/context` | Combine selected sessions into context |

## New files
- `lib/memory.ts` — memory storage, generation, and CRUD functions

## Test plan
- [x] `GET /api/memories` returns empty list initially
- [x] `PUT /api/memories/:id` saves markdown file
- [x] `GET /api/memories/:id` reads it back
- [x] `DELETE /api/memories/:id` removes it (returns 404 after)
- [x] `POST /api/memories/context` combines multiple memories
- [x] `POST /api/memories/:id/generate` creates summary from `.jsonl` conversation
- [x] Error handling: returns 400 when no conversation found
- [x] Build passes (`bun build --target=bun server.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)